### PR TITLE
fix(arch): Full URL Endpoint Mode + Rectifier pattern for third-party API compatibility

### DIFF
--- a/crates/server/src/routes/models.rs
+++ b/crates/server/src/routes/models.rs
@@ -15,8 +15,6 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use utils::url::normalize_base_url;
-
 use crate::{DeploymentImpl, error::ApiError};
 
 const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com";
@@ -72,16 +70,13 @@ async fn list_models(
 
     let models = match query.api_type.as_str() {
         "openai" | "openai-compatible" => {
-            let url = normalize_base_url(&query.api_type, &base_url);
-            list_openai_models(&client, &url, &api_key).await?
+            list_openai_models(&client, &base_url, &api_key).await?
         }
         "anthropic" | "anthropic-compatible" => {
-            let url = normalize_base_url(&query.api_type, &base_url);
-            list_anthropic_models(&client, &url, &api_key).await?
+            list_anthropic_models(&client, &base_url, &api_key).await?
         }
         "google" => {
-            let url = normalize_base_url("google", &base_url);
-            list_google_models(&client, &url, &api_key).await?
+            list_google_models(&client, &base_url, &api_key).await?
         }
         other => {
             return Err(ApiError::BadRequest(format!(
@@ -102,16 +97,16 @@ async fn verify_model(
 
     let verified = match payload.api_type.as_str() {
         "openai" | "openai-compatible" => {
-            let url = normalize_base_url(&payload.api_type, &payload.base_url);
-            verify_openai_model(&client, &url, &payload.api_key, &payload.model_id).await
+            let base_url = trim_trailing_slash(&payload.base_url);
+            verify_openai_model(&client, &base_url, &payload.api_key, &payload.model_id).await
         }
         "anthropic" | "anthropic-compatible" => {
-            let url = normalize_base_url(&payload.api_type, &payload.base_url);
-            verify_anthropic_model(&client, &url, &payload.api_key, &payload.model_id).await
+            let base_url = trim_trailing_slash(&payload.base_url);
+            verify_anthropic_model(&client, &base_url, &payload.api_key, &payload.model_id).await
         }
         "google" => {
-            let url = normalize_base_url("google", &payload.base_url);
-            verify_google_model(&client, &url, &payload.api_key, &payload.model_id).await
+            let base_url = trim_trailing_slash(&payload.base_url);
+            verify_google_model(&client, &base_url, &payload.api_key, &payload.model_id).await
         }
         other => {
             return Err(ApiError::BadRequest(format!(

--- a/crates/server/src/routes/planning_drafts.rs
+++ b/crates/server/src/routes/planning_drafts.rs
@@ -308,11 +308,46 @@ async fn send_message(
     if missing_planner {
         {
             let cfg = deployment.config().read().await;
-            if let Some(model) = cfg.workflow_model_library.iter().find(|m| !m.api_key.is_empty()) {
+            // Priority 1: Anthropic-protocol models (most common for orchestrator chat)
+            if let Some(model) = cfg.workflow_model_library.iter().find(|m| {
+                !m.api_key.is_empty()
+                && matches!(m.api_type.as_str(), "anthropic" | "anthropic-compatible")
+            }) {
                 tracing::info!(
                     draft_id = %draft_id,
                     model_id = %model.model_id,
-                    "Auto-filling planner config from workflow_model_library"
+                    "Auto-filling planner config from workflow_model_library (anthropic)"
+                );
+                draft.planner_model_id = Some(model.model_id.clone());
+                draft.planner_api_type = Some(model.api_type.clone());
+                draft.planner_base_url = Some(model.base_url.clone());
+                if let Err(e) = draft.set_api_key(&model.api_key) {
+                    tracing::warn!(draft_id = %draft_id, "Failed to encrypt auto-filled API key: {e}");
+                }
+            }
+            // Priority 2: OpenAI-protocol models (fallback)
+            else if let Some(model) = cfg.workflow_model_library.iter().find(|m| {
+                !m.api_key.is_empty()
+                && matches!(m.api_type.as_str(), "openai" | "openai-compatible")
+            }) {
+                tracing::info!(
+                    draft_id = %draft_id,
+                    model_id = %model.model_id,
+                    "Auto-filling planner config from workflow_model_library (openai-compatible)"
+                );
+                draft.planner_model_id = Some(model.model_id.clone());
+                draft.planner_api_type = Some(model.api_type.clone());
+                draft.planner_base_url = Some(model.base_url.clone());
+                if let Err(e) = draft.set_api_key(&model.api_key) {
+                    tracing::warn!(draft_id = %draft_id, "Failed to encrypt auto-filled API key: {e}");
+                }
+            }
+            // Priority 3: Any model with API key (last resort)
+            else if let Some(model) = cfg.workflow_model_library.iter().find(|m| !m.api_key.is_empty()) {
+                tracing::info!(
+                    draft_id = %draft_id,
+                    model_id = %model.model_id,
+                    "Auto-filling planner config from workflow_model_library (any)"
                 );
                 draft.planner_model_id = Some(model.model_id.clone());
                 draft.planner_api_type = Some(model.api_type.clone());

--- a/crates/services/src/services/cc_switch.rs
+++ b/crates/services/src/services/cc_switch.rs
@@ -97,17 +97,12 @@ fn create_codex_config(
 ) -> anyhow::Result<()> {
     let config_path = codex_home.join("config.toml");
 
-    // Use a custom provider when a custom base URL is configured.
-    // Normalize base_url: Codex CLI appends endpoint paths (e.g. /responses) directly
-    // to base_url, so it must end with /v1 for OpenAI-compatible gateways.
-    let normalized_base_url;
     let (provider_key, base_url_str) = match base_url {
         Some(url) => {
-            // Codex CLI always uses OpenAI protocol, so "openai" ensures /v1 is appended.
-            normalized_base_url = utils::url::normalize_base_url("openai", url);
-            ("custom", normalized_base_url.as_str())
+            let trimmed = url.trim_end_matches('/');
+            ("custom", trimmed.to_string())
         }
-        None => ("openai", "https://api.openai.com/v1"),
+        None => ("openai", "https://api.openai.com/v1".to_string()),
     };
     let wire_api = resolve_codex_wire_api();
 
@@ -118,17 +113,10 @@ model = "{model}"
 [model_providers.{provider_key}]
 name = "{provider_key}"
 base_url = "{base_url_str}"
-api_key = "{api_key}"
 "#
     );
 
-    // Default to OpenAI Responses API for compatibility with most custom gateways.
-    // Set SOLODAWN_CODEX_WIRE_API=codex when provider explicitly requires /codex.
     config_content.push_str(&format!("wire_api = \"{wire_api}\"\n"));
-
-    // Skip interactive sandbox setup prompt by pre-configuring sandbox and approval.
-    // Without this, Codex CLI presents an interactive menu asking the user to select
-    // a sandbox type, which blocks automated PTY-based execution.
     config_content.push_str("approval_policy = \"on-request\"\n");
     config_content.push_str("sandbox_permissions = [\"disk-full-read-access\", \"disk-write-folder\"]\n");
 
@@ -141,7 +129,7 @@ api_key = "{api_key}"
         model_provider = %provider_key,
         base_url = %base_url_str,
         wire_api = %wire_api,
-        "Created Codex config.toml for authentication skip"
+        "Created Codex config.toml for authentication skip (api_key via env var only)"
     );
 
     Ok(())

--- a/crates/services/src/services/cc_switch.rs
+++ b/crates/services/src/services/cc_switch.rs
@@ -93,7 +93,7 @@ fn create_codex_config(
     codex_home: &Path,
     base_url: Option<&str>,
     model: &str,
-    api_key: &str,
+    _api_key: &str,
 ) -> anyhow::Result<()> {
     let config_path = codex_home.join("config.toml");
 

--- a/crates/services/src/services/orchestrator/llm.rs
+++ b/crates/services/src/services/orchestrator/llm.rs
@@ -14,7 +14,7 @@ use twox_hash::XxHash64;
 
 use utils::url::{ApiFormat, resolve_endpoint};
 
-#[allow(deprecated)]
+#[allow(deprecated, unused_imports)]
 use utils::url::normalize_base_url;
 
 use super::{
@@ -1079,15 +1079,17 @@ mod anthropic_protocol_tests {
 
 #[cfg(test)]
 mod url_normalization_tests {
-    #[allow(deprecated)]
+    #[allow(deprecated, unused_imports)]
     use utils::url::normalize_base_url;
 
+    #[allow(deprecated)]
     #[test]
     fn test_openai_official_gets_v1() {
         let url = normalize_base_url("openai", "https://api.openai.com");
         assert_eq!(url, "https://api.openai.com/v1");
     }
 
+    #[allow(deprecated)]
     #[test]
     fn test_openai_compatible_no_v1_append() {
         let url = normalize_base_url(

--- a/crates/services/src/services/orchestrator/llm.rs
+++ b/crates/services/src/services/orchestrator/llm.rs
@@ -286,6 +286,8 @@ impl OpenAICompatibleClient {
                     content: choice.message.content.clone(),
                     usage,
                 });
+            } else {
+                return Err(anyhow::anyhow!("LLM returned empty choices"));
             }
         }
 

--- a/crates/services/src/services/orchestrator/llm.rs
+++ b/crates/services/src/services/orchestrator/llm.rs
@@ -12,6 +12,9 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use twox_hash::XxHash64;
 
+use utils::url::{ApiFormat, resolve_endpoint};
+
+#[allow(deprecated)]
 use utils::url::normalize_base_url;
 
 use super::{
@@ -197,18 +200,19 @@ impl OpenAICompatibleClient {
             .build()
             .expect("Failed to create HTTP client");
 
-        let base_url = normalize_base_url(&config.api_type, &config.base_url);
+        let endpoint = resolve_endpoint(&config.api_type, &config.base_url);
 
         tracing::info!(
             api_type = %config.api_type,
             input_url = %config.base_url,
-            final_base_url = %base_url,
-            "OpenAI-compatible LLM client URL normalized"
+            resolved_url = %endpoint.url,
+            api_format = %endpoint.api_format,
+            "OpenAI-compatible LLM client endpoint resolved"
         );
 
         Self {
             client,
-            base_url,
+            base_url: endpoint.url,
             api_key: config.api_key.clone(),
             model: config.model.clone(),
         }
@@ -264,23 +268,70 @@ impl OpenAICompatibleClient {
             return Err(anyhow::anyhow!("LLM API error: {status} - {body}"));
         }
 
-        let chat_response: ChatResponse = response.json().await?;
-        // [G24-005] Return an error when the API returns no choices instead of
-        // silently producing an empty string that downstream code cannot distinguish
-        // from a legitimate empty response.
-        let content = chat_response
-            .choices
-            .first()
-            .map(|c| c.message.content.clone())
-            .ok_or_else(|| anyhow::anyhow!("LLM API returned empty choices array"))?;
+        // Read body as text first for multi-format parsing (Rectifier pattern)
+        let body = response.text().await.map_err(|e| {
+            tracing::error!("Failed to read OpenAI-compatible response body: {e}");
+            e
+        })?;
 
-        let usage = chat_response.usage.map(|u| LLMUsage {
-            prompt_tokens: u.prompt_tokens,
-            completion_tokens: u.completion_tokens,
-            total_tokens: u.total_tokens,
-        });
+        // Strategy 1: Standard OpenAI format { "choices": [{ "message": { "content" } }] }
+        if let Ok(chat_response) = serde_json::from_str::<ChatResponse>(&body) {
+            if let Some(choice) = chat_response.choices.first() {
+                let usage = chat_response.usage.map(|u| LLMUsage {
+                    prompt_tokens: u.prompt_tokens,
+                    completion_tokens: u.completion_tokens,
+                    total_tokens: u.total_tokens,
+                });
+                return Ok(LLMResponse {
+                    content: choice.message.content.clone(),
+                    usage,
+                });
+            }
+        }
 
-        Ok(LLMResponse { content, usage })
+        // Strategy 2: Try alternative response formats from third-party gateways
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
+            // { "content": "..." } direct
+            if let Some(content) = json.get("content").and_then(|c| c.as_str()) {
+                return Ok(LLMResponse { content: content.to_string(), usage: None });
+            }
+            // { "output": "..." } (OpenAI Responses API string form)
+            if let Some(output) = json.get("output").and_then(|o| o.as_str()) {
+                return Ok(LLMResponse { content: output.to_string(), usage: None });
+            }
+            // { "output": [{ "type": "message", "content": [{ "type": "output_text", "text": "..." }] }] }
+            if let Some(arr) = json.get("output").and_then(|o| o.as_array()) {
+                let mut text = String::new();
+                for item in arr {
+                    if item.get("type").and_then(|t| t.as_str()) == Some("message") {
+                        if let Some(blocks) = item.get("content").and_then(|c| c.as_array()) {
+                            for b in blocks {
+                                if b.get("type").and_then(|t| t.as_str()) == Some("output_text") {
+                                    if let Some(t) = b.get("text").and_then(|t| t.as_str()) {
+                                        text.push_str(t);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if !text.is_empty() {
+                    return Ok(LLMResponse { content: text, usage: None });
+                }
+            }
+            // Error object
+            if let Some(error) = json.get("error") {
+                let msg = error.get("message").and_then(|m| m.as_str()).unwrap_or("unknown");
+                return Err(anyhow::anyhow!("LLM API returned error: {msg}"));
+            }
+        }
+
+        tracing::error!(
+            body_len = body.len(),
+            body_preview = %body.chars().take(500).collect::<String>(),
+            "Failed to parse OpenAI-compatible response in all known formats"
+        );
+        Err(anyhow::anyhow!("error decoding response body: unrecognized format"))
     }
 }
 
@@ -335,18 +386,19 @@ impl AnthropicCompatibleClient {
             .build()
             .expect("Failed to create HTTP client");
 
-        let base_url = normalize_base_url(&config.api_type, &config.base_url);
+        let endpoint = resolve_endpoint(&config.api_type, &config.base_url);
 
         tracing::info!(
             api_type = %config.api_type,
             input_url = %config.base_url,
-            final_base_url = %base_url,
-            "Anthropic-compatible LLM client URL normalized"
+            resolved_url = %endpoint.url,
+            api_format = %endpoint.api_format,
+            "Anthropic-compatible LLM client endpoint resolved"
         );
 
         Self {
             client,
-            base_url,
+            base_url: endpoint.url,
             api_key: config.api_key.clone(),
             model: config.model.clone(),
         }
@@ -853,30 +905,26 @@ pub fn build_terminal_completion_prompt(
 /// [`ResilientLLMClient`] that wraps the primary provider plus all fallbacks
 /// with automatic circuit-breaking and failover.  Otherwise the original
 /// single-provider path is used (fully backward compatible).
-/// Determine whether to use Anthropic protocol based on api_type and base_url.
-fn should_use_anthropic_protocol(config: &OrchestratorConfig) -> bool {
-    // Explicit api_type takes priority — user knows their endpoint best
-    match config.api_type.as_str() {
-        "anthropic" | "anthropic-compatible" => return true,
-        "openai" | "openai-compatible" | "google" => return false,
-        _ => {}
-    }
-    // Auto-detect only when api_type is not explicitly set
-    let url_lower = config.base_url.to_lowercase();
-    url_lower.contains("/anthropic")
-}
-
-/// Build a single rate-limited LLM client based on api_type and base_url.
+/// Build a single rate-limited LLM client based on api_type.
+///
+/// Uses `resolve_endpoint` to determine both the URL and `ApiFormat` from the
+/// configured `api_type`. Protocol selection is driven entirely by `api_type`,
+/// not by URL content inspection.
 fn build_single_client(config: &OrchestratorConfig) -> anyhow::Result<Box<dyn LLMClient>> {
     let rps = config.rate_limit_requests_per_second;
-    if should_use_anthropic_protocol(config) {
-        let client = AnthropicCompatibleClient::new(config);
-        let client = RateLimitedClient::new(client, rps)?;
-        Ok(Box::new(client))
-    } else {
-        let client = OpenAICompatibleClient::new(config);
-        let client = RateLimitedClient::new(client, rps)?;
-        Ok(Box::new(client))
+    let endpoint = resolve_endpoint(&config.api_type, &config.base_url);
+
+    match endpoint.api_format {
+        ApiFormat::AnthropicMessages => {
+            let client = AnthropicCompatibleClient::new(config);
+            let client = RateLimitedClient::new(client, rps)?;
+            Ok(Box::new(client))
+        }
+        ApiFormat::OpenAIChat | ApiFormat::Google => {
+            let client = OpenAICompatibleClient::new(config);
+            let client = RateLimitedClient::new(client, rps)?;
+            Ok(Box::new(client))
+        }
     }
 }
 
@@ -985,7 +1033,8 @@ mod anthropic_protocol_tests {
             model: "glm-5".to_string(),
             ..Default::default()
         };
-        assert!(!should_use_anthropic_protocol(&config));
+        let endpoint = resolve_endpoint(&config.api_type, &config.base_url);
+        assert_eq!(endpoint.api_format, ApiFormat::OpenAIChat, "openai-compatible must use OpenAI format regardless of URL content");
     }
 
     #[test]
@@ -997,11 +1046,12 @@ mod anthropic_protocol_tests {
             model: "claude-sonnet-4-20250514".to_string(),
             ..Default::default()
         };
-        assert!(should_use_anthropic_protocol(&config));
+        let endpoint = resolve_endpoint(&config.api_type, &config.base_url);
+        assert_eq!(endpoint.api_format, ApiFormat::AnthropicMessages);
     }
 
     #[test]
-    fn test_unknown_type_with_anthropic_url_autodetects() {
+    fn test_unknown_type_defaults_to_openai() {
         let config = OrchestratorConfig {
             api_type: String::new(),
             base_url: "https://proxy.example.com/anthropic/v1".to_string(),
@@ -1009,7 +1059,8 @@ mod anthropic_protocol_tests {
             model: "test".to_string(),
             ..Default::default()
         };
-        assert!(should_use_anthropic_protocol(&config));
+        let endpoint = resolve_endpoint(&config.api_type, &config.base_url);
+        assert_eq!(endpoint.api_format, ApiFormat::OpenAIChat, "unknown api_type defaults to OpenAI, no URL guessing");
     }
 
     #[test]
@@ -1021,12 +1072,14 @@ mod anthropic_protocol_tests {
             model: "gpt-4".to_string(),
             ..Default::default()
         };
-        assert!(!should_use_anthropic_protocol(&config));
+        let endpoint = resolve_endpoint(&config.api_type, &config.base_url);
+        assert_eq!(endpoint.api_format, ApiFormat::OpenAIChat);
     }
 }
 
 #[cfg(test)]
 mod url_normalization_tests {
+    #[allow(deprecated)]
     use utils::url::normalize_base_url;
 
     #[test]
@@ -1042,57 +1095,6 @@ mod url_normalization_tests {
             "https://open.bigmodel.cn/api/paas/v4",
         );
         assert_eq!(url, "https://open.bigmodel.cn/api/paas/v4");
-    }
-
-    #[test]
-    fn test_openai_already_has_v1_not_doubled() {
-        let url = normalize_base_url("openai", "https://api.openai.com/v1");
-        assert_eq!(url, "https://api.openai.com/v1");
-    }
-
-    #[test]
-    fn test_anthropic_official_gets_v1() {
-        let url = normalize_base_url("anthropic", "https://api.anthropic.com");
-        assert_eq!(url, "https://api.anthropic.com/v1");
-    }
-
-    #[test]
-    fn test_anthropic_compatible_appends_v1() {
-        let url = normalize_base_url(
-            "anthropic-compatible",
-            "https://open.bigmodel.cn/api/anthropic",
-        );
-        assert_eq!(url, "https://open.bigmodel.cn/api/anthropic/v1");
-    }
-
-    #[test]
-    fn test_trailing_slash_stripped() {
-        let url = normalize_base_url("openai-compatible", "https://example.com/api/");
-        assert_eq!(url, "https://example.com/api");
-    }
-
-    #[test]
-    fn test_zhipuai_v4_preserved() {
-        let url = normalize_base_url(
-            "openai-compatible",
-            "https://open.bigmodel.cn/api/paas/v4",
-        );
-        assert_eq!(url, "https://open.bigmodel.cn/api/paas/v4");
-    }
-
-    #[test]
-    fn test_empty_api_type_no_v1_append() {
-        let url = normalize_base_url("", "https://custom.provider.com/api");
-        assert_eq!(url, "https://custom.provider.com/api");
-    }
-
-    #[test]
-    fn test_google_type_no_v1_append() {
-        let url = normalize_base_url("google", "https://generativelanguage.googleapis.com");
-        assert_eq!(
-            url,
-            "https://generativelanguage.googleapis.com"
-        );
     }
 }
 
@@ -1113,29 +1115,14 @@ mod full_chain_tests {
             ..Default::default()
         };
 
-        // Verify config is valid
         assert!(config.validate().is_ok(), "Config should be valid");
 
-        // Verify protocol selection
-        assert!(
-            !should_use_anthropic_protocol(&config),
-            "ZhipuAI openai-compatible should NOT use Anthropic protocol"
-        );
+        let endpoint = resolve_endpoint(&config.api_type, &config.base_url);
+        assert_eq!(endpoint.api_format, ApiFormat::OpenAIChat, "ZhipuAI openai-compatible should use OpenAI format");
+        assert_eq!(endpoint.url, "https://open.bigmodel.cn/api/paas/v4", "URL preserved, no /v1 appended");
 
-        // Verify URL normalization preserves provider path (no /v1 appended)
-        let normalized = normalize_base_url(&config.api_type, &config.base_url);
-        assert_eq!(
-            normalized, "https://open.bigmodel.cn/api/paas/v4",
-            "openai-compatible must NOT append /v1 to provider URL"
-        );
-
-        // Verify the final request URL that would be constructed
-        let expected_chat_url = format!("{normalized}/chat/completions");
-        assert_eq!(
-            expected_chat_url,
-            "https://open.bigmodel.cn/api/paas/v4/chat/completions",
-            "Final chat URL must use provider's v4 path"
-        );
+        let chat_url = endpoint.chat_endpoint();
+        assert_eq!(chat_url, "https://open.bigmodel.cn/api/paas/v4/chat/completions");
     }
 
     #[test]
@@ -1150,25 +1137,13 @@ mod full_chain_tests {
 
         assert!(config.validate().is_ok(), "Config should be valid");
 
-        assert!(
-            should_use_anthropic_protocol(&config),
-            "ZhipuAI anthropic-compatible SHOULD use Anthropic protocol"
-        );
+        let endpoint = resolve_endpoint(&config.api_type, &config.base_url);
+        assert_eq!(endpoint.api_format, ApiFormat::AnthropicMessages);
+        // Key fix: no /v1 appended for anthropic-compatible
+        assert_eq!(endpoint.url, "https://open.bigmodel.cn/api/anthropic");
 
-        // Verify URL normalization appends /v1 for anthropic-compatible
-        let normalized = normalize_base_url(&config.api_type, &config.base_url);
-        assert_eq!(
-            normalized, "https://open.bigmodel.cn/api/anthropic/v1",
-            "anthropic-compatible must append /v1 (Anthropic protocol requires /v1/messages)"
-        );
-
-        // Verify the final messages URL for Anthropic protocol
-        let expected_msg_url = format!("{normalized}/messages");
-        assert_eq!(
-            expected_msg_url,
-            "https://open.bigmodel.cn/api/anthropic/v1/messages",
-            "Final messages URL must use provider's anthropic path with /v1"
-        );
+        let msg_url = endpoint.chat_endpoint();
+        assert_eq!(msg_url, "https://open.bigmodel.cn/api/anthropic/messages");
     }
 
     #[test]
@@ -1181,24 +1156,14 @@ mod full_chain_tests {
             ..Default::default()
         };
 
-        assert!(config.validate().is_ok(), "Config should be valid");
+        assert!(config.validate().is_ok());
 
-        assert!(
-            !should_use_anthropic_protocol(&config),
-            "Official OpenAI should NOT use Anthropic protocol"
-        );
+        let endpoint = resolve_endpoint(&config.api_type, &config.base_url);
+        assert_eq!(endpoint.api_format, ApiFormat::OpenAIChat);
+        assert_eq!(endpoint.url, "https://api.openai.com");
 
-        let normalized = normalize_base_url(&config.api_type, &config.base_url);
-        assert_eq!(
-            normalized, "https://api.openai.com/v1",
-            "Official openai MUST append /v1"
-        );
-
-        let expected_chat_url = format!("{normalized}/chat/completions");
-        assert_eq!(
-            expected_chat_url,
-            "https://api.openai.com/v1/chat/completions"
-        );
+        let chat_url = endpoint.chat_endpoint();
+        assert_eq!(chat_url, "https://api.openai.com/chat/completions");
     }
 
     #[test]
@@ -1211,50 +1176,32 @@ mod full_chain_tests {
             ..Default::default()
         };
 
-        assert!(config.validate().is_ok(), "Config should be valid");
+        assert!(config.validate().is_ok());
 
-        assert!(
-            should_use_anthropic_protocol(&config),
-            "Official Anthropic SHOULD use Anthropic protocol"
-        );
+        let endpoint = resolve_endpoint(&config.api_type, &config.base_url);
+        assert_eq!(endpoint.api_format, ApiFormat::AnthropicMessages);
+        assert_eq!(endpoint.url, "https://api.anthropic.com");
 
-        let normalized = normalize_base_url(&config.api_type, &config.base_url);
-        assert_eq!(
-            normalized, "https://api.anthropic.com/v1",
-            "Official anthropic MUST append /v1"
-        );
-
-        let expected_msg_url = format!("{normalized}/messages");
-        assert_eq!(
-            expected_msg_url,
-            "https://api.anthropic.com/v1/messages"
-        );
+        let msg_url = endpoint.chat_endpoint();
+        assert_eq!(msg_url, "https://api.anthropic.com/messages");
     }
 
     #[test]
     fn test_protocol_detection_all_explicit_types() {
-        let cases = vec![
-            ("anthropic", true),
-            ("anthropic-compatible", true),
-            ("openai", false),
-            ("openai-compatible", false),
-            ("google", false),
+        let cases: Vec<(&str, ApiFormat)> = vec![
+            ("anthropic", ApiFormat::AnthropicMessages),
+            ("anthropic-compatible", ApiFormat::AnthropicMessages),
+            ("openai", ApiFormat::OpenAIChat),
+            ("openai-compatible", ApiFormat::OpenAIChat),
+            ("google", ApiFormat::Google),
         ];
 
-        for (api_type, expected_anthropic) in cases {
-            let config = OrchestratorConfig {
-                api_type: api_type.to_string(),
-                base_url: "https://example.com".to_string(),
-                api_key: "test".to_string(),
-                model: "test".to_string(),
-                ..Default::default()
-            };
+        for (api_type, expected_format) in cases {
+            let endpoint = resolve_endpoint(api_type, "https://example.com");
             assert_eq!(
-                should_use_anthropic_protocol(&config),
-                expected_anthropic,
-                "api_type '{}' should {}use Anthropic protocol",
-                api_type,
-                if expected_anthropic { "" } else { "NOT " }
+                endpoint.api_format, expected_format,
+                "api_type '{}' should resolve to {:?}",
+                api_type, expected_format
             );
         }
     }

--- a/crates/services/src/services/orchestrator/tests.rs
+++ b/crates/services/src/services/orchestrator/tests.rs
@@ -377,7 +377,7 @@ mod orchestrator_tests {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("POST"))
-            .and(path("/v1/chat/completions"))
+            .and(path("/chat/completions"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "choices": [{
                     "message": {
@@ -424,7 +424,7 @@ mod orchestrator_tests {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("POST"))
-            .and(path("/v1/chat/completions"))
+            .and(path("/chat/completions"))
             .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
                 "error": {
                     "message": "Invalid API key",
@@ -461,7 +461,7 @@ mod orchestrator_tests {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("POST"))
-            .and(path("/v1/chat/completions"))
+            .and(path("/chat/completions"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "choices": []
             })))
@@ -2907,7 +2907,7 @@ next_action: handoff";
         let mock_server = MockServer::start().await;
 
         Mock::given(method("POST"))
-            .and(path("/v1/chat/completions"))
+            .and(path("/chat/completions"))
             .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
                 "error": "Internal server error"
             })))

--- a/crates/utils/src/url.rs
+++ b/crates/utils/src/url.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 /// Identifies which wire protocol / response format to expect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -6,6 +7,16 @@ pub enum ApiFormat {
     OpenAIChat,
     AnthropicMessages,
     Google,
+}
+
+impl fmt::Display for ApiFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ApiFormat::OpenAIChat => write!(f, "OpenAIChat"),
+            ApiFormat::AnthropicMessages => write!(f, "AnthropicMessages"),
+            ApiFormat::Google => write!(f, "Google"),
+        }
+    }
 }
 
 /// The result of resolving a user-provided URL + api_type into a concrete
@@ -16,6 +27,22 @@ pub struct ResolvedEndpoint {
     pub url: String,
     /// Which wire protocol to speak against this URL.
     pub api_format: ApiFormat,
+}
+
+impl ResolvedEndpoint {
+    /// Returns the full chat endpoint URL by appending the protocol-specific
+    /// path to the base URL.
+    ///
+    /// - `OpenAIChat` → `{url}/chat/completions`
+    /// - `AnthropicMessages` → `{url}/messages`
+    /// - `Google` → `{url}` (Google uses query parameters, not path suffixes)
+    pub fn chat_endpoint(&self) -> String {
+        match self.api_format {
+            ApiFormat::OpenAIChat => format!("{}/chat/completions", self.url),
+            ApiFormat::AnthropicMessages => format!("{}/messages", self.url),
+            ApiFormat::Google => self.url.clone(),
+        }
+    }
 }
 
 /// Resolve a raw user-provided base URL and an api_type string into a

--- a/crates/utils/src/url.rs
+++ b/crates/utils/src/url.rs
@@ -1,15 +1,55 @@
+use serde::{Deserialize, Serialize};
+
+/// Identifies which wire protocol / response format to expect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ApiFormat {
+    OpenAIChat,
+    AnthropicMessages,
+    Google,
+}
+
+/// The result of resolving a user-provided URL + api_type into a concrete
+/// endpoint description.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedEndpoint {
+    /// The URL to use — stripped of trailing slashes but otherwise unmodified.
+    pub url: String,
+    /// Which wire protocol to speak against this URL.
+    pub api_format: ApiFormat,
+}
+
+/// Resolve a raw user-provided base URL and an api_type string into a
+/// `ResolvedEndpoint`.
+///
+/// **Full URL Endpoint Mode**: the URL is used exactly as the user typed it
+/// (only trailing slashes are stripped).  No `/v1`, `/chat/completions`, or
+/// `/messages` suffixes are appended here — those are the responsibility of
+/// the HTTP client layer (`chat_endpoint()`).
+///
+/// The `api_type` string determines only the *protocol* (`ApiFormat`), not
+/// any URL manipulation.
+pub fn resolve_endpoint(api_type: &str, raw_url: &str) -> ResolvedEndpoint {
+    let url = raw_url.trim_end_matches('/').to_string();
+    let api_format = match api_type {
+        "anthropic" | "anthropic-compatible" => ApiFormat::AnthropicMessages,
+        "google" => ApiFormat::Google,
+        _ => ApiFormat::OpenAIChat,
+    };
+    ResolvedEndpoint { url, api_format }
+}
+
 /// Normalize a base URL for LLM API providers.
 ///
-/// For official providers (`"openai"`, `"anthropic"`), ensures the `/v1` path
-/// is present. For compatible/third-party providers, uses the URL exactly as
-/// configured by the user to avoid corrupting provider-specific paths (e.g.,
-/// ZhipuAI uses `/v4` not `/v1`).
-///
-/// Trailing slashes are always stripped.
+/// # Deprecation
+/// Prefer [`resolve_endpoint`] which implements Full URL Endpoint Mode —
+/// the URL is used as-is without appending `/v1`.
+#[deprecated(
+    since = "0.0.154",
+    note = "Use `resolve_endpoint` instead. Full URL Endpoint Mode means no path manipulation."
+)]
 pub fn normalize_base_url(api_type: &str, raw_url: &str) -> String {
     let trimmed = raw_url.trim_end_matches('/');
     match api_type {
-        // All types that use the /v1 path convention.
         "openai" | "anthropic" | "anthropic-compatible" => {
             if trimmed.ends_with("/v1") {
                 trimmed.to_string()
@@ -17,7 +57,6 @@ pub fn normalize_base_url(api_type: &str, raw_url: &str) -> String {
                 format!("{trimmed}/v1")
             }
         }
-        // For "openai-compatible", "google", etc. — use the URL as provided.
         _ => trimmed.to_string(),
     }
 }
@@ -27,97 +66,136 @@ mod tests {
     use super::*;
 
     #[test]
-    fn official_openai_gets_v1() {
+    fn resolve_openai_defaults_to_openai_chat() {
+        let ep = resolve_endpoint("openai", "https://api.openai.com");
+        assert_eq!(ep.url, "https://api.openai.com");
+        assert_eq!(ep.api_format, ApiFormat::OpenAIChat);
+    }
+
+    #[test]
+    fn resolve_anthropic_uses_anthropic_messages() {
+        let ep = resolve_endpoint("anthropic", "https://api.anthropic.com");
+        assert_eq!(ep.url, "https://api.anthropic.com");
+        assert_eq!(ep.api_format, ApiFormat::AnthropicMessages);
+    }
+
+    #[test]
+    fn resolve_anthropic_compatible_uses_anthropic_messages() {
+        let ep = resolve_endpoint(
+            "anthropic-compatible",
+            "https://open.bigmodel.cn/api/anthropic",
+        );
+        assert_eq!(ep.url, "https://open.bigmodel.cn/api/anthropic");
+        assert_eq!(ep.api_format, ApiFormat::AnthropicMessages);
+    }
+
+    #[test]
+    fn resolve_google_uses_google_format() {
+        let ep = resolve_endpoint("google", "https://generativelanguage.googleapis.com");
+        assert_eq!(ep.url, "https://generativelanguage.googleapis.com");
+        assert_eq!(ep.api_format, ApiFormat::Google);
+    }
+
+    #[test]
+    fn resolve_strips_trailing_slash() {
+        let ep = resolve_endpoint("openai-compatible", "https://example.com/api/");
+        assert_eq!(ep.url, "https://example.com/api");
+    }
+
+    #[test]
+    fn resolve_preserves_v1_if_user_included_it() {
+        let ep = resolve_endpoint("openai-compatible", "https://example.com/v1");
+        assert_eq!(ep.url, "https://example.com/v1");
+        assert_eq!(ep.api_format, ApiFormat::OpenAIChat);
+    }
+
+    #[test]
+    fn resolve_preserves_zhipuai_v4() {
+        let ep = resolve_endpoint("openai-compatible", "https://open.bigmodel.cn/api/paas/v4");
+        assert_eq!(ep.url, "https://open.bigmodel.cn/api/paas/v4");
+        assert_eq!(ep.api_format, ApiFormat::OpenAIChat);
+    }
+
+    // ---- Legacy normalize_base_url tests (deprecated) ----
+
+    #[allow(deprecated)]
+    #[test]
+    fn legacy_official_openai_gets_v1() {
         assert_eq!(
             normalize_base_url("openai", "https://api.openai.com"),
             "https://api.openai.com/v1"
         );
     }
 
+    #[allow(deprecated)]
     #[test]
-    fn compatible_no_v1_appended() {
+    fn legacy_compatible_no_v1_appended() {
         assert_eq!(
-            normalize_base_url(
-                "openai-compatible",
-                "https://open.bigmodel.cn/api/paas/v4"
-            ),
+            normalize_base_url("openai-compatible", "https://open.bigmodel.cn/api/paas/v4"),
             "https://open.bigmodel.cn/api/paas/v4"
         );
     }
 
+    #[allow(deprecated)]
     #[test]
-    fn already_has_v1_not_doubled() {
+    fn legacy_already_has_v1_not_doubled() {
         assert_eq!(
             normalize_base_url("openai", "https://api.openai.com/v1"),
             "https://api.openai.com/v1"
         );
     }
 
+    #[allow(deprecated)]
     #[test]
-    fn trailing_slash_stripped() {
+    fn legacy_trailing_slash_stripped() {
         assert_eq!(
             normalize_base_url("openai-compatible", "https://example.com/api/"),
             "https://example.com/api"
         );
     }
 
+    #[allow(deprecated)]
     #[test]
-    fn anthropic_official_gets_v1() {
+    fn legacy_anthropic_official_gets_v1() {
         assert_eq!(
             normalize_base_url("anthropic", "https://api.anthropic.com"),
             "https://api.anthropic.com/v1"
         );
     }
 
+    #[allow(deprecated)]
     #[test]
-    fn anthropic_compatible_gets_v1() {
+    fn legacy_anthropic_compatible_gets_v1() {
         assert_eq!(
-            normalize_base_url(
-                "anthropic-compatible",
-                "https://open.bigmodel.cn/api/anthropic"
-            ),
+            normalize_base_url("anthropic-compatible", "https://open.bigmodel.cn/api/anthropic"),
             "https://open.bigmodel.cn/api/anthropic/v1"
         );
     }
 
+    #[allow(deprecated)]
     #[test]
-    fn anthropic_compatible_already_has_v1() {
+    fn legacy_anthropic_compatible_already_has_v1() {
         assert_eq!(
-            normalize_base_url(
-                "anthropic-compatible",
-                "https://open.bigmodel.cn/api/anthropic/v1"
-            ),
+            normalize_base_url("anthropic-compatible", "https://open.bigmodel.cn/api/anthropic/v1"),
             "https://open.bigmodel.cn/api/anthropic/v1"
         );
     }
 
+    #[allow(deprecated)]
     #[test]
-    fn empty_api_type_no_v1() {
+    fn legacy_empty_api_type_no_v1() {
         assert_eq!(
             normalize_base_url("", "https://example.com/api"),
             "https://example.com/api"
         );
     }
 
+    #[allow(deprecated)]
     #[test]
-    fn google_type_no_v1() {
+    fn legacy_google_type_no_v1() {
         assert_eq!(
-            normalize_base_url(
-                "google",
-                "https://generativelanguage.googleapis.com"
-            ),
+            normalize_base_url("google", "https://generativelanguage.googleapis.com"),
             "https://generativelanguage.googleapis.com"
-        );
-    }
-
-    #[test]
-    fn zhipuai_v4_preserved() {
-        assert_eq!(
-            normalize_base_url(
-                "openai-compatible",
-                "https://open.bigmodel.cn/api/paas/v4"
-            ),
-            "https://open.bigmodel.cn/api/paas/v4"
         );
     }
 }

--- a/frontend/src/components/setup/SetupWizardStep2ModelContainer.tsx
+++ b/frontend/src/components/setup/SetupWizardStep2ModelContainer.tsx
@@ -66,9 +66,7 @@ export function SetupWizardStep2ModelContainer({
     const url = baseUrl.trim();
     if (!url || !apiType) return null;
 
-    const isCompatible = apiType.endsWith('-compatible');
-
-    if (isCompatible && url.endsWith('/v1')) {
+    if (url.endsWith('/v1')) {
       return t('step3.warnings.urlV1Compatible');
     }
 

--- a/frontend/src/components/workflow/steps/Step3Models.tsx
+++ b/frontend/src/components/workflow/steps/Step3Models.tsx
@@ -115,9 +115,7 @@ export const Step3Models: React.FC<Step3ModelsProps> = ({
     const apiType = formData.apiType;
     if (!url || !apiType) return null;
 
-    const isCompatible = apiType.endsWith('-compatible');
-
-    if (isCompatible && url.endsWith('/v1')) {
+    if (url.endsWith('/v1')) {
       return t('step3.warnings.urlV1Compatible');
     }
 
@@ -600,6 +598,11 @@ export const Step3Models: React.FC<Step3ModelsProps> = ({
                 <p className="flex items-center gap-half text-xs text-warning mt-half">
                   <WarningIcon className="size-icon-xs shrink-0" weight="fill" />
                   {urlWarning}
+                </p>
+              )}
+              {!urlWarning && (formData.apiType === 'openai-compatible' || formData.apiType === 'anthropic-compatible') && (
+                <p className="text-xs text-low mt-half">
+                  {t('step3.warnings.urlHint')}
                 </p>
               )}
             </Field>

--- a/frontend/src/i18n/locales/en/workflow.json
+++ b/frontend/src/i18n/locales/en/workflow.json
@@ -197,9 +197,10 @@
       "modelIdRequired": "Model ID is required"
     },
     "warnings": {
-      "urlV1Compatible": "URL ends with /v1 but API type is set to compatible mode. Compatible providers typically do not need /v1 in the URL.",
+      "urlV1Compatible": "URL ends with /v1. The URL will be used exactly as entered — no paths are appended automatically. If the API requires /v1, keep it; otherwise, you may remove it.",
       "zhipuaiOpenai": "ZhipuAI detected. Consider using \"openai-compatible\" as the API type.",
-      "zhipuaiAnthropic": "ZhipuAI detected. Consider using \"anthropic-compatible\" as the API type."
+      "zhipuaiAnthropic": "ZhipuAI detected. Consider using \"anthropic-compatible\" as the API type.",
+      "urlHint": "Enter the complete base URL. It will be used exactly as-is (e.g. https://api.example.com/v1)."
     }
   },
   "step4": {

--- a/frontend/src/i18n/locales/es/workflow.json
+++ b/frontend/src/i18n/locales/es/workflow.json
@@ -196,9 +196,10 @@
       "modelIdRequired": "Model ID is required"
     },
     "warnings": {
-      "urlV1Compatible": "La URL termina en /v1 pero el tipo de API está configurado en modo compatible. Los proveedores compatibles normalmente no necesitan /v1 en la URL.",
+      "urlV1Compatible": "La URL termina en /v1. La URL se usará tal como se ingresó; no se agregarán rutas automáticamente. Si la API requiere /v1, déjela; de lo contrario, puede eliminarla.",
       "zhipuaiOpenai": "Se detectó ZhipuAI. Considere usar \"openai-compatible\" como tipo de API.",
-      "zhipuaiAnthropic": "Se detectó ZhipuAI. Considere usar \"anthropic-compatible\" como tipo de API."
+      "zhipuaiAnthropic": "Se detectó ZhipuAI. Considere usar \"anthropic-compatible\" como tipo de API.",
+      "urlHint": "Ingrese la URL base completa. Se usará tal cual (ej. https://api.example.com/v1)."
     }
   },
   "step4": {

--- a/frontend/src/i18n/locales/ja/workflow.json
+++ b/frontend/src/i18n/locales/ja/workflow.json
@@ -196,9 +196,10 @@
       "modelIdRequired": "Model ID is required"
     },
     "warnings": {
-      "urlV1Compatible": "URLが /v1 で終わっていますが、APIタイプが互換モードに設定されています。互換プロバイダーは通常、URLに /v1 を含める必要はありません。",
+      "urlV1Compatible": "URLが /v1 で終わっています。URLは入力された通りに使用され、パスは自動追加されません。API に /v1 が必要な場合はそのままにし、不要な場合は削除してください。",
       "zhipuaiOpenai": "ZhipuAIが検出されました。APIタイプを \"openai-compatible\" に変更することを検討してください。",
-      "zhipuaiAnthropic": "ZhipuAIが検出されました。APIタイプを \"anthropic-compatible\" に変更することを検討してください。"
+      "zhipuaiAnthropic": "ZhipuAIが検出されました。APIタイプを \"anthropic-compatible\" に変更することを検討してください。",
+      "urlHint": "完全なベースURLを入力してください。入力された通りに使用されます（例：https://api.example.com/v1）。"
     }
   },
   "step4": {

--- a/frontend/src/i18n/locales/ko/workflow.json
+++ b/frontend/src/i18n/locales/ko/workflow.json
@@ -196,9 +196,10 @@
       "modelIdRequired": "Model ID is required"
     },
     "warnings": {
-      "urlV1Compatible": "URL이 /v1로 끝나지만 API 유형이 호환 모드로 설정되어 있습니다. 호환 공급자는 일반적으로 URL에 /v1이 필요하지 않습니다.",
+      "urlV1Compatible": "URL이 /v1로 끝납니다. URL은 입력한 그대로 사용되며, 경로가 자동으로 추가되지 않습니다. API에 /v1이 필요한 경우 그대로 두고, 그렇지 않은 경우 제거할 수 있습니다.",
       "zhipuaiOpenai": "ZhipuAI가 감지되었습니다. API 유형을 \"openai-compatible\"로 변경하는 것을 고려하세요.",
-      "zhipuaiAnthropic": "ZhipuAI가 감지되었습니다. API 유형을 \"anthropic-compatible\"로 변경하는 것을 고려하세요."
+      "zhipuaiAnthropic": "ZhipuAI가 감지되었습니다. API 유형을 \"anthropic-compatible\"로 변경하는 것을 고려하세요.",
+      "urlHint": "전체 기본 URL을 입력하세요. 입력한 그대로 사용됩니다 (예: https://api.example.com/v1)."
     }
   },
   "step4": {

--- a/frontend/src/i18n/locales/zh-Hans/workflow.json
+++ b/frontend/src/i18n/locales/zh-Hans/workflow.json
@@ -198,9 +198,10 @@
       "modelIdRequired": "请选择或输入模型 ID"
     },
     "warnings": {
-      "urlV1Compatible": "URL 以 /v1 结尾，但 API 类型设置为兼容模式。兼容模式的提供商通常不需要在 URL 中包含 /v1。",
+      "urlV1Compatible": "URL 以 /v1 结尾。系统将原样使用您输入的 URL，不会自动追加路径。如果 API 需要 /v1 则保留，否则可以移除。",
       "zhipuaiOpenai": "检测到智谱AI地址。建议将 API 类型更改为 \"openai-compatible\"。",
-      "zhipuaiAnthropic": "检测到智谱AI地址。建议将 API 类型更改为 \"anthropic-compatible\"。"
+      "zhipuaiAnthropic": "检测到智谱AI地址。建议将 API 类型更改为 \"anthropic-compatible\"。",
+      "urlHint": "请输入完整的基础 URL，系统将原样使用（例如 https://api.example.com/v1）。"
     }
   },
   "step4": {

--- a/frontend/src/i18n/locales/zh-Hant/workflow.json
+++ b/frontend/src/i18n/locales/zh-Hant/workflow.json
@@ -196,9 +196,10 @@
       "modelIdRequired": "Model ID is required"
     },
     "warnings": {
-      "urlV1Compatible": "URL 以 /v1 結尾，但 API 類型設定為相容模式。相容模式的提供商通常不需要在 URL 中包含 /v1。",
+      "urlV1Compatible": "URL 以 /v1 結尾。系統將原樣使用您輸入的 URL，不會自動追加路徑。如果 API 需要 /v1 則保留，否則可以移除。",
       "zhipuaiOpenai": "偵測到智譜AI位址。建議將 API 類型更改為 \"openai-compatible\"。",
-      "zhipuaiAnthropic": "偵測到智譜AI位址。建議將 API 類型更改為 \"anthropic-compatible\"。"
+      "zhipuaiAnthropic": "偵測到智譜AI位址。建議將 API 類型更改為 \"anthropic-compatible\"。",
+      "urlHint": "請輸入完整的基礎 URL，系統將原樣使用（例如 https://api.example.com/v1）。"
     }
   },
   "step4": {


### PR DESCRIPTION
## Summary

- **Full URL Endpoint Mode**: Introduce `ApiFormat` enum and `resolve_endpoint()` in `url.rs` — URL used as-is, no `/v1` appending. Separates protocol selection from URL manipulation.
- **Rectifier Pattern**: `OpenAICompatibleClient` now uses multi-format response parsing to handle diverse third-party gateway responses (OpenAI, direct content, output string, Responses API array).
- **API Format Separation**: Replace `should_use_anthropic_protocol()` with `resolve_endpoint()`-based protocol selection via `ApiFormat` match.
- **Priority-based Auto-fill**: `planning_drafts.rs` auto-fill now prioritizes Anthropic-protocol models to prevent Codex models from polluting orchestrator config.
- **Codex Config Fix (G22-010)**: `config.toml` no longer includes `api_key`; key injected only via `OPENAI_API_KEY` env var.
- **Frontend URL hints**: Updated warnings and hints for all 6 locales to explain Full URL Endpoint Mode behavior.

Fixes three architectural problems:

1. Adding a Codex-specific model breaks the orchestrator workspace conversation with "LLM call failed: error decoding response body"
2. Launching a Codex terminal while using Claude model causes Codex to fail completely
3. Third-party APIs (GLM etc.) conflict with official subscriptions — GLM working breaks others and vice versa

## Test plan

- [ ] `cargo check` passes
- [ ] Add a Codex (OpenAI-compatible) model, verify orchestrator chat still works
- [ ] Use Claude model for conversation, launch Codex terminal, verify both work
- [ ] Configure GLM third-party endpoint, verify it works alongside official Anthropic/OpenAI models
- [ ] Verify frontend URL hint appears for compatible API types
