### PR TITLE
fix: deferred follow-ups — Lagged-resume + judge-approved test-opt (migrations/quality-gate flagged)

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -101,3 +101,15 @@ runs:
         # extracted straight onto PATH so `cargo nextest` resolves it.
         curl -LsSf --retry 5 --retry-connrefused "${URL}" | tar zxf - -C "${HOME}/.cargo/bin"
         cargo-nextest --version
+
+    - name: Cache Rust build outputs (registry, git, target)
+      # Complements sccache: sccache (GHA backend) caches rustc compilation
+      # outputs, but NOT cargo's registry index, dependency metadata, or final
+      # link artifacts — those are re-done every run. rust-cache restores
+      # ~/.cargo/{registry,git} + target/, auto-scoping by job + Cargo.lock +
+      # rustc version and pruning stale deps (safe alongside sccache; a raw
+      # actions/cache on `target` would bloat and evict sccache's GHA entries).
+      # Keyed on Cargo.lock so a clean dependency set never serves stale.
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        cache-all-crates: "true"

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -57,6 +57,17 @@ jobs:
     if: ${{ needs.changes.outputs.backend == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Single source of truth for the crate selection shared by the prime,
+    # clippy, and nextest steps. Keeping it in one place prevents the three
+    # steps from silently diverging (e.g. adding a crate or dropping the tray
+    # exclusion in only one place), which would let nextest test a crate clippy
+    # never linted, or vice-versa. NOTE: this only unifies *crate selection* —
+    # the target-scope flags deliberately differ per step (prime `--tests`,
+    # clippy `--all-targets`, nextest `--lib`) and so do feature flags (clippy
+    # uniquely passes `--all-features`); those intentional differences are left
+    # untouched here.
+    env:
+      CARGO_SELECT: --workspace --exclude solodawn-tray
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -73,10 +84,10 @@ jobs:
     # no incremental) so clippy and nextest can share the same build
     # artifacts instead of rebuilding twice.
     - name: Prime build artifacts (shared by clippy + nextest)
-      run: cargo build --workspace --exclude solodawn-tray --profile ci --tests --quiet
+      run: cargo build $CARGO_SELECT --profile ci --tests --quiet
 
     - name: Run cargo clippy
-      run: cargo clippy --workspace --exclude solodawn-tray --all-targets --all-features --profile ci -- -D warnings
+      run: cargo clippy $CARGO_SELECT --all-targets --all-features --profile ci -- -D warnings
 
     # Performance: removed `--test-threads=1`. The original single-threaded
     # setting was an extremely broad hammer that forced the entire test
@@ -95,7 +106,7 @@ jobs:
       # win). NOTE: nextest's `--profile` is its own run-config profile (from
       # .config/nextest.toml), NOT a Cargo profile — there is no `ci` nextest
       # profile, so `--profile ci` errored with "profile `ci` not found".
-      run: cargo nextest run --workspace --exclude solodawn-tray --cargo-profile ci --lib
+      run: cargo nextest run $CARGO_SELECT --cargo-profile ci --lib
 
     - name: Check generated types are up-to-date
       run: cargo run --bin generate_types --profile ci -- --check

--- a/.github/workflows/ci-installer.yml
+++ b/.github/workflows/ci-installer.yml
@@ -31,7 +31,6 @@ jobs:
       uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 # stable
       with:
         toolchain: nightly-2025-12-04
-        components: clippy
 
     - name: Cache Rust dependencies
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -44,16 +43,19 @@ jobs:
         restore-keys: ${{ runner.os }}-cargo-installer-
 
     # --- Node.js setup ---
+    # Install pnpm BEFORE setup-node so setup-node's `cache: 'pnpm'` resolver
+    # (which runs `pnpm store path`) can find pnpm on PATH.
+    - name: Install pnpm
+      run: npm install -g pnpm@10.13.1
+
     - name: Setup Node.js
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       with:
         node-version: '22'
-
-    - name: Install pnpm
-      run: npm install -g pnpm@10.13.1
+        cache: 'pnpm'
 
     - name: Install frontend dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
 
     # --- Build frontend ---
     - name: Build frontend

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -18,6 +18,13 @@ on:
 jobs:
   notify:
     name: Notify SoloDawn API
+    # Skip cleanly when the upstream run carries no real signal (e.g. a
+    # path-filtered Docker Build Check on a PR that touches no docker paths).
+    # A 'skipped' top-level conclusion is never produced by a real failure
+    # (those are failure/cancelled/timed_out), and the consumer only logs the
+    # conclusion, so notifying for it is pure waste. Notification-only,
+    # non-required workflow — this changes no gating.
+    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/crates/server/tests/slash_commands_integration_test.rs
+++ b/crates/server/tests/slash_commands_integration_test.rs
@@ -161,15 +161,26 @@ async fn test_find_all_presets_is_capped() {
     let pool = &deployment.db().pool;
     let test_run = Uuid::new_v4().simple().to_string();
 
+    // Insert 510 presets (must exceed the 500 cap) inside a single transaction.
+    // Batching collapses 510 per-row pool-acquire/commit round-trips into one
+    // commit; row count, uniqueness, and is_system=0 match SlashCommandPreset::create.
+    let mut tx = pool.begin().await.expect("Failed to begin transaction");
     for idx in 0..510 {
-        create_test_preset(
-            pool,
-            &format!("/limit-cmd-{test_run}-{idx:03}"),
-            "Bounded list test preset",
-            "Template",
+        sqlx::query(
+            r"
+            INSERT INTO slash_command_preset (id, command, description, prompt_template, is_system)
+            VALUES (?1, ?2, ?3, ?4, 0)
+            ",
         )
-        .await;
+        .bind(Uuid::new_v4().to_string())
+        .bind(format!("/limit-cmd-{test_run}-{idx:03}"))
+        .bind("Bounded list test preset")
+        .bind("Template")
+        .execute(&mut *tx)
+        .await
+        .expect("Failed to insert test preset");
     }
+    tx.commit().await.expect("Failed to commit transaction");
 
     let all = SlashCommandPreset::find_all(pool)
         .await

--- a/crates/services/src/services/terminal/output_fanout.rs
+++ b/crates/services/src/services/terminal/output_fanout.rs
@@ -198,7 +198,24 @@ impl OutputSubscription {
 
         // Then receive from live stream with deduplication
         loop {
-            let chunk = self.rx.recv().await?;
+            // [G33] On Lagged (the broadcast buffer overflowed and dropped
+            // chunks because this subscriber fell behind) skip the lost window
+            // and keep streaming, instead of propagating the error and tearing
+            // down the whole output stream (gRPC stream_output / WS). Only a
+            // genuine Closed ends the subscription.
+            let chunk = match self.rx.recv().await {
+                Ok(chunk) => chunk,
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    tracing::warn!(
+                        skipped,
+                        "terminal output subscription lagged; resuming after dropped chunks"
+                    );
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    return Err(broadcast::error::RecvError::Closed);
+                }
+            };
             if chunk.seq <= self.last_seq {
                 // Skip duplicate (already seen in replay or previous live)
                 continue;

--- a/crates/services/tests/git_watcher_integration_test.rs
+++ b/crates/services/tests/git_watcher_integration_test.rs
@@ -328,8 +328,11 @@ mod git_watcher_tests {
                 "completed",
             );
             create_commit(&repo_path, &commit_msg);
-            // Wait longer than poll_interval to ensure watcher detects each commit
-            tokio::time::sleep(Duration::from_millis(150)).await;
+            // Wait longer than poll_interval (50ms) to ensure watcher detects
+            // each commit in its own poll window. 80ms keeps a safe margin over
+            // one poll cycle (50ms sleep + git subprocess) while trimming idle
+            // wall-clock vs the prior 150ms.
+            tokio::time::sleep(Duration::from_millis(80)).await;
         }
 
         // Collect all messages
@@ -384,10 +387,14 @@ mod git_watcher_tests {
         }
 
         // Collect two TerminalCompleted events.
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(4);
+        // The outer deadline and per-recv timeout are failure-only upper bounds
+        // (a passing run receives both events within one ~300ms poll window, so
+        // these values do not affect success latency). Tightened from 4s/800ms
+        // to surface a real regression faster without changing semantics.
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(1500);
         let mut terminal_ids = Vec::new();
         while terminal_ids.len() < 2 && tokio::time::Instant::now() < deadline {
-            match timeout(Duration::from_millis(800), receiver.recv()).await {
+            match timeout(Duration::from_millis(500), receiver.recv()).await {
                 Ok(Ok(BusMessage::TerminalCompleted(event))) => {
                     terminal_ids.push(event.terminal_id);
                 }

--- a/crates/services/tests/terminal_timeout_test.rs
+++ b/crates/services/tests/terminal_timeout_test.rs
@@ -34,11 +34,23 @@ mod tests {
             .await
             .expect("Process kill by PID should succeed");
 
-        // Wait for process to exit after SIGTERM/taskkill
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        // Cleanup should remove dead processes
-        manager.cleanup().await;
+        // Poll until the killed process is reaped, or hit a hard deadline.
+        // kill() already waits for OS-level exit; this bounded loop only waits for
+        // the tracking map to observe it, so a healthy machine returns in tens of
+        // ms instead of a fixed 200ms sleep. cleanup() and list_running() are both
+        // idempotent reapers, so repeated calls are safe. A real cleanup regression
+        // (entry never reaped) still fails the final assertion at the 500ms deadline.
+        let deadline = std::time::Instant::now() + Duration::from_millis(500);
+        loop {
+            manager.cleanup().await;
+            if manager.list_running().await.is_empty() {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
 
         let running_after = manager.list_running().await;
         assert_eq!(running_after.len(), 0, "Dead process should be removed");
@@ -110,11 +122,23 @@ mod tests {
                 .expect("Process kill by PID should succeed");
         }
 
-        // Wait for processes to exit after SIGTERM/taskkill
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        // Cleanup should remove all dead processes
-        manager.cleanup().await;
+        // Poll until all killed processes are reaped, or hit a hard deadline.
+        // kill() already waits for OS-level exit; this bounded loop only waits for
+        // the tracking map to observe it, returning early on healthy machines
+        // instead of a fixed 200ms sleep. cleanup() and list_running() are both
+        // idempotent reapers, so repeated calls are safe. A real cleanup regression
+        // still fails the final assertion at the 500ms deadline.
+        let deadline = std::time::Instant::now() + Duration::from_millis(500);
+        loop {
+            manager.cleanup().await;
+            if manager.list_running().await.is_empty() {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
 
         assert_eq!(
             manager.list_running().await.len(),


### PR DESCRIPTION
## What

Follow-up to #26 — the **deferred items** from the multi-agent bug hunt.

### Included (verified)
- **runner/WS Lagged-resume** (`output_fanout.rs`): `OutputSubscription::recv()` propagated broadcast `Lagged` via `?`, so the gRPC `stream_output` task and the WS path **tore down the whole terminal output stream** on a transient subscriber lag. `recv()` now skips the dropped window and resumes, ending only on `Closed`. Fixes both consumers centrally.
- **Judge-approved test-opt follow-ups** (none reduces coverage or masks failures):
  - `ci-basic`: hoist the shared crate-selection into a job-level `env` (stops prime/clippy/nextest silently diverging); `setup-rust`: add `Swatinem/rust-cache` (complements sccache — caches registry/git/target + link artifacts).
  - `ci-installer`: drop unused clippy component; pnpm store cache + `--frozen-lockfile`.
  - `ci-notify`: skip the runner for `skipped` upstream conclusions.
  - integration tests: poll-until-deadline instead of fixed sleeps (`git_watcher`, `terminal_timeout`); single batched-transaction insert (`slash_commands` cap test).

**Verified:** `clippy -D warnings` (services + server) clean; `output_fanout --lib` + `git_watcher` / `terminal_timeout` / `slash_commands` integration tests pass under nextest (per-process isolation, matching CI).

## Needs your decision — NOT auto-applied

1. **The 2 FK-OFF migration data-loss bugs** (`20260202…fix_workflow_project_id_type.sql`, `20260417…cascade_merges_repo_fk.sql`). `PRAGMA foreign_keys=OFF` is silently ignored inside sqlx's transaction → FKs stay on → migration 1's `DROP TABLE workflow` cascade-deletes children (data loss); migration 2's `INSERT…SELECT` aborts on a dangling ref (stuck upgrade). **Cannot be safely fixed retroactively:** both are already applied in prod (migration 1's own comment says *"do NOT edit"*); editing breaks sqlx checksum validation on every DB that ran them; deleted rows can't be un-deleted; **fresh installs are unaffected** (empty tables → no cascade/abort), so there's no go-forward bug. The correct fix is a *policy* change for future rebuilds (`PRAGMA foreign_keys=OFF` outside the txn, or the SQLite 12-step rebuild) — a maintainer call.

2. **ci-quality docs-skip path-filter (test-opt #7) — deliberately omitted.** It requires branch protection to require a new always-run `Quality Gate Status` aggregate instead of `quality-gate`; without that admin change, adding the skip would **wedge docs-only PRs** on the now-skipped required check. Apply the workflow change only together with the branch-protection update.

3. **Pre-existing latent test failure discovered during verification:** `slash_commands_integration_test::test_system_preset_protection` expects 1 system preset but finds 7 (in its own isolated DB — unrelated to these changes; no change here touches preset seeding). It's a `tests/` integration test CI never runs (`--lib` gate), so it's been failing silently — a stale expectation vs. seeded system presets. Flagging for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
