### PR TITLE
fix(orchestrator): reliable subscription acceptance-review + scope-aware scoring

### DIFF
--- a/crates/db/migrations/20260621000000_bump_retired_sonnet_model.sql
+++ b/crates/db/migrations/20260621000000_bump_retired_sonnet_model.sql
@@ -1,0 +1,14 @@
+-- Sonnet 4 (`claude-sonnet-4-20250514`) was retired 2026-06-15. The seeded
+-- official model `model-claude-sonnet` still pinned that id, so orchestrator
+-- Claude Code terminals launched on a retired model and stalled with
+-- "model unavailable" (claude reports the model retired/unavailable and waits at
+-- a /model prompt). Bump it to the current Sonnet (`claude-sonnet-4-6`), which
+-- the subscription endpoint accepts — this mirrors the orchestrator's native
+-- fallback model in `agent.rs` / `llm.rs`.
+--
+-- Guarded on the old id so a user who already re-pointed this model is untouched.
+UPDATE model_config
+SET api_model_id = 'claude-sonnet-4-6',
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = 'model-claude-sonnet'
+  AND api_model_id = 'claude-sonnet-4-20250514';

--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -180,8 +180,21 @@ impl ClaudeCode {
     /// `--resume <uuid>` — see `build_interactive_command_parts` /
     /// `build_interactive_follow_up_command_parts`.
     fn build_interactive_command_builder(&self) -> CommandBuilder {
-        let mut builder =
-            CommandBuilder::new(base_command(self.claude_code_router.unwrap_or(false)));
+        // The interactive transport is exclusively for native-OAuth (subscription)
+        // users, who have the genuine `claude` binary installed locally. Invoke it
+        // directly instead of via `npx -y @anthropic-ai/claude-code@<ver>`: on
+        // Windows the npx launcher resolves to `npx.cmd` (a batch file), and
+        // std::process rejects batch-file arguments containing newlines
+        // ("batch file arguments are invalid") — which breaks the multi-line
+        // single-turn planning prompt that is passed positionally. The native
+        // binary has no such restriction. The Claude Code Router path still needs
+        // npx, so keep it there.
+        let base = if self.claude_code_router.unwrap_or(false) {
+            base_command(true)
+        } else {
+            "claude".to_string()
+        };
+        let mut builder = CommandBuilder::new(base);
 
         // Tier-1 approvals for native OAuth: skip permission prompts. (No `--bare`
         // — it's stripped for native OAuth and breaks token loading; see contract.)

--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -1593,13 +1593,27 @@ impl LocalContainerService {
             .or_else(|| model_config.as_ref().map(|m| m.name.clone()))
             .unwrap_or_default();
 
-        // Provision (or re-open) the per-logical-session interactive home. On a
-        // follow-up, reuse the same session UUID so `--resume` appends to the
-        // same transcript; on initial, mint a fresh one.
-        let home = services::services::cc_switch::create_interactive_isolated_home(
-            follow_up_session_id.as_deref(),
-            &working_dir,
-        )
+        // Provision (or re-open) the interactive home. Native-OAuth
+        // (subscription, no resolved api key) reuses the user's GLOBAL `~/.claude`
+        // — already authorized AND onboarded — so the worker terminal does not hit
+        // a fresh-config login prompt + first-run model picker (the isolated copy
+        // only carried `.credentials.json`/`settings.json`, never the
+        // `~/.claude.json` onboarding/account state). API-key / relay modes keep an
+        // isolated per-session home (their key is a secret that must be scrubbed on
+        // teardown). On a follow-up, reuse the same session UUID so `--resume`
+        // appends to the same transcript.
+        let use_global_home = resolved_api_key.is_none();
+        let home = if use_global_home {
+            services::services::cc_switch::create_interactive_global_home(
+                follow_up_session_id.as_deref(),
+                &working_dir,
+            )
+        } else {
+            services::services::cc_switch::create_interactive_isolated_home(
+                follow_up_session_id.as_deref(),
+                &working_dir,
+            )
+        }
         .map_err(|e| ContainerError::Other(anyhow!("create interactive home failed: {e}")))?;
 
         // Unified 3-mode auth setup: writes per-mode files into the home (native

--- a/crates/services/src/services/cc_switch.rs
+++ b/crates/services/src/services/cc_switch.rs
@@ -533,6 +533,15 @@ pub struct InteractiveHome {
     pub session_uuid: String,
     /// `<home_dir>/projects/<slug>/<uuid>.jsonl` — what S5 tails.
     pub transcript_path: std::path::PathBuf,
+    /// When true, `home_dir` is the user's REAL global `~/.claude` (shared,
+    /// already authorized + onboarded), NOT an isolated per-session copy. The
+    /// interactive auth setup then must NOT redirect `CLAUDE_CONFIG_DIR` or copy
+    /// credentials (the global config is already complete), and teardown must
+    /// NEVER delete it (the `cleanup_isolated_home` temp-dir guard enforces this
+    /// regardless, but callers should also skip the cleanup call). Used for the
+    /// native-OAuth (subscription) path so worker terminals reuse the global
+    /// login + onboarding instead of hitting a fresh-config login + model picker.
+    pub is_shared_global: bool,
 }
 
 /// Provision (or re-open) the per-logical-session interactive CLAUDE home.
@@ -555,6 +564,41 @@ pub fn create_interactive_isolated_home(
         home_dir,
         session_uuid,
         transcript_path,
+        is_shared_global: false,
+    })
+}
+
+/// Provision an interactive session that reuses the user's GLOBAL `~/.claude`
+/// instead of an isolated per-session copy.
+///
+/// The native-OAuth (subscription) path uses this so worker terminals inherit
+/// the global login AND first-run onboarding (`~/.claude.json`) — the isolated
+/// home only carried `.credentials.json`/`settings.json`, so the unmodified
+/// `claude` binary saw a fresh config and blocked on a login prompt + first-run
+/// model picker. The transcript still lands in the default
+/// `~/.claude/projects/<slug>/<uuid>.jsonl`, so S5's tailer reads it unchanged;
+/// `--session-id` keeps concurrent terminals on separate transcript files.
+///
+/// The returned home is flagged `is_shared_global` so [`setup_interactive_auth`]
+/// neither redirects `CLAUDE_CONFIG_DIR` nor copies credentials, and teardown
+/// skips it (the `cleanup_isolated_home` temp-dir guard also refuses to delete
+/// anything outside `<temp>/solodawn`).
+pub fn create_interactive_global_home(
+    session_uuid: Option<&str>,
+    working_dir: &Path,
+) -> anyhow::Result<InteractiveHome> {
+    let session_uuid = session_uuid
+        .map(ToString::to_string)
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let home_dir = dirs::home_dir()
+        .map(|h| h.join(".claude"))
+        .ok_or_else(|| anyhow::anyhow!("cannot resolve home dir for global claude config"))?;
+    let transcript_path = interactive_transcript_path(&home_dir, working_dir, &session_uuid);
+    Ok(InteractiveHome {
+        home_dir,
+        session_uuid,
+        transcript_path,
+        is_shared_global: true,
     })
 }
 
@@ -719,52 +763,71 @@ pub fn setup_interactive_auth(
     let mut unset: Vec<String> = Vec::new();
     let mut settings_arg: Option<std::path::PathBuf> = None;
 
-    // ALWAYS: redirect home + cap retries (PROBE: CLAUDE_CONFIG_DIR is the real
-    // redirect in 2.1.177; CLAUDE_HOME kept for RB-37 cleanup scan).
-    set.insert("CLAUDE_CONFIG_DIR".to_string(), home_str.clone());
-    set.insert("CLAUDE_HOME".to_string(), home_str);
+    // Redirect home + cap retries (PROBE: CLAUDE_CONFIG_DIR is the real redirect
+    // in 2.1.177; CLAUDE_HOME kept for RB-37 cleanup scan). For the SHARED GLOBAL
+    // home (native subscription) we must NOT redirect: claude has to use its real
+    // default config so it inherits the complete login + first-run onboarding
+    // state (`~/.claude.json`), which an isolated copy never carried — that is
+    // what forced the login prompt + model picker. Force-clear any inherited
+    // redirect so an ambient `CLAUDE_CONFIG_DIR` cannot point the child at a
+    // stale/empty dir.
+    if home.is_shared_global {
+        unset.push("CLAUDE_CONFIG_DIR".to_string());
+        unset.push("CLAUDE_HOME".to_string());
+    } else {
+        set.insert("CLAUDE_CONFIG_DIR".to_string(), home_str.clone());
+        set.insert("CLAUDE_HOME".to_string(), home_str);
+    }
     set.insert("CLAUDE_CODE_MAX_RETRIES".to_string(), "2".to_string());
 
     match mode {
         InteractiveAuthMode::NativeOauth => {
-            // Copy the genuine OAuth credentials into the isolated home so the
-            // unmodified `claude` binary authenticates against the subscription
-            // plan (no key extracted into SoloDawn's own auth path). Mirrors the
-            // `-p` native-auth copy.
-            let global_creds = native_credentials_src.join(".credentials.json");
-            let isolated_creds = home_dir.join(".credentials.json");
-            if global_creds.exists() {
-                if let Err(e) = std::fs::copy(&global_creds, &isolated_creds) {
+            // For the SHARED GLOBAL home, `home_dir` IS the live `~/.claude`, so
+            // there is nothing to copy (the real credentials + settings are
+            // already there) — and copying would be actively harmful: a
+            // `std::fs::copy(src, dst)` with src == dst can truncate the real
+            // `.credentials.json`. Only the ISOLATED-home path copies.
+            if !home.is_shared_global {
+                // Copy the genuine OAuth credentials into the isolated home so the
+                // unmodified `claude` binary authenticates against the subscription
+                // plan (no key extracted into SoloDawn's own auth path). Mirrors the
+                // `-p` native-auth copy.
+                let global_creds = native_credentials_src.join(".credentials.json");
+                let isolated_creds = home_dir.join(".credentials.json");
+                if global_creds.exists() {
+                    if let Err(e) = std::fs::copy(&global_creds, &isolated_creds) {
+                        tracing::warn!(
+                            error = %e,
+                            "Failed to copy native credentials into interactive home"
+                        );
+                    }
+                } else {
                     tracing::warn!(
-                        error = %e,
-                        "Failed to copy native credentials into interactive home"
+                        creds = %global_creds.display(),
+                        "Native interactive auth selected but ~/.claude/.credentials.json is missing"
                     );
                 }
-            } else {
-                tracing::warn!(
-                    creds = %global_creds.display(),
-                    "Native interactive auth selected but ~/.claude/.credentials.json is missing"
-                );
-            }
-            // Copy settings.json for user preferences if present (do not clobber).
-            // SANITIZE the copy: the user's global settings.json `env` block may
-            // contain a billing-routing var (ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN
-            // / ANTHROPIC_BASE_URL / CLAUDE_CODE_OAUTH_TOKEN). claude honors
-            // settings.json `env`, so copying it verbatim would re-introduce a
-            // key/relay endpoint inside the isolated home and defeat the
-            // process-level scrub (env_remove only strips the inherited PROCESS
-            // env — it cannot reach a value baked into settings.json on disk).
-            // Strip those keys so native OAuth stays on the subscription plan.
-            let global_settings = native_credentials_src.join("settings.json");
-            let isolated_settings = home_dir.join("settings.json");
-            if global_settings.exists() && !isolated_settings.exists() {
-                if let Err(e) =
-                    copy_native_settings_scrubbing_billing_env(&global_settings, &isolated_settings)
-                {
-                    tracing::warn!(
-                        error = %e,
-                        "Failed to copy/sanitize native settings.json into interactive home"
-                    );
+                // Copy settings.json for user preferences if present (do not clobber).
+                // SANITIZE the copy: the user's global settings.json `env` block may
+                // contain a billing-routing var (ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN
+                // / ANTHROPIC_BASE_URL / CLAUDE_CODE_OAUTH_TOKEN). claude honors
+                // settings.json `env`, so copying it verbatim would re-introduce a
+                // key/relay endpoint inside the isolated home and defeat the
+                // process-level scrub (env_remove only strips the inherited PROCESS
+                // env — it cannot reach a value baked into settings.json on disk).
+                // Strip those keys so native OAuth stays on the subscription plan.
+                let global_settings = native_credentials_src.join("settings.json");
+                let isolated_settings = home_dir.join("settings.json");
+                if global_settings.exists() && !isolated_settings.exists() {
+                    if let Err(e) = copy_native_settings_scrubbing_billing_env(
+                        &global_settings,
+                        &isolated_settings,
+                    ) {
+                        tracing::warn!(
+                            error = %e,
+                            "Failed to copy/sanitize native settings.json into interactive home"
+                        );
+                    }
                 }
             }
             // No key env. Scrub anything that could redirect billing off the
@@ -1228,47 +1291,25 @@ impl CCSwitchService {
                             e
                         })?;
                 } else if using_native_auth {
-                    // Copy native credentials into the isolated CLAUDE_HOME
-                    // so the CLI can authenticate in the sandboxed environment.
-                    if let Some(home) = dirs::home_dir() {
-                        let global_creds = home.join(".claude").join(".credentials.json");
-                        let isolated_creds = claude_home.join(".credentials.json");
-                        if global_creds.exists() {
-                            if let Err(e) = std::fs::copy(&global_creds, &isolated_creds) {
-                                tracing::warn!(
-                                    terminal_id = %terminal.id,
-                                    error = %e,
-                                    "Failed to copy native credentials to isolated CLAUDE_HOME"
-                                );
-                            }
-                        }
-                        // Also copy settings.json if it exists (for user preferences).
-                        // SANITIZE the copy: now that CLAUDE_CONFIG_DIR makes claude
-                        // actually read this isolated dir, a verbatim copy of the user's
-                        // global settings.json `env` block (which claude honors) could
-                        // re-introduce a billing-routing key (ANTHROPIC_API_KEY /
-                        // ANTHROPIC_AUTH_TOKEN / ANTHROPIC_BASE_URL / CLAUDE_CODE_OAUTH_TOKEN)
-                        // inside the native (subscription) home and redirect billing
-                        // off-plan. Strip those keys, mirroring the interactive native path.
-                        let global_settings = home.join(".claude").join("settings.json");
-                        let isolated_settings = claude_home.join("settings.json");
-                        if global_settings.exists() && !isolated_settings.exists() {
-                            if let Err(e) = copy_native_settings_scrubbing_billing_env(
-                                &global_settings,
-                                &isolated_settings,
-                            ) {
-                                tracing::warn!(
-                                    terminal_id = %terminal.id,
-                                    error = %e,
-                                    "Failed to copy/sanitize native settings.json into isolated CLAUDE_HOME"
-                                );
-                            }
-                        }
-                    }
+                    // Reuse the user's GLOBAL ~/.claude (already authorized AND
+                    // onboarded) instead of an isolated copy. The previous approach
+                    // copied only .credentials.json + settings.json into the isolated
+                    // home — never ~/.claude.json (onboarding/account state) — so the
+                    // unmodified `claude` binary saw a fresh config and blocked the
+                    // orchestrator terminal on an interactive login prompt + first-run
+                    // model picker. Drop the isolated redirect set above and clear any
+                    // inherited one so claude uses its real default config and inherits
+                    // the live subscription login + onboarding. No credential copy: the
+                    // global config is already complete, and a std::fs::copy of
+                    // .credentials.json onto itself can truncate the real file. The
+                    // empty isolated dir created above holds no secrets.
+                    env.set.remove("CLAUDE_CONFIG_DIR");
+                    env.set.remove("CLAUDE_HOME");
+                    env.unset.push("CLAUDE_CONFIG_DIR".to_string());
+                    env.unset.push("CLAUDE_HOME".to_string());
                     tracing::info!(
                         terminal_id = %terminal.id,
-                        claude_home = %claude_home.display(),
-                        "Using Claude Code native OAuth credentials (copied to isolated home)"
+                        "Using GLOBAL ~/.claude for native OAuth (inherits login + onboarding; no isolated copy)"
                     );
                     // Native OAuth (subscription) auth: scrub every billing-routing
                     // env var so a subscription credential is NEVER paired with an
@@ -1344,7 +1385,11 @@ impl CCSwitchService {
                     }
                 }
 
-                // Set model for all tiers
+                // Set model for all tiers. The model comes from the terminal's
+                // model_config; it MUST be a current/available model id (a retired
+                // id such as claude-sonnet-4-20250514 makes claude report "model
+                // unavailable" and stall). Forcing it here also overrides any stale
+                // default in the inherited global ~/.claude config.
                 env.set.insert("ANTHROPIC_MODEL".to_string(), model.clone());
                 env.set
                     .insert("ANTHROPIC_DEFAULT_HAIKU_MODEL".to_string(), model.clone());

--- a/crates/services/src/services/orchestrator/agent.rs
+++ b/crates/services/src/services/orchestrator/agent.rs
@@ -203,8 +203,25 @@ impl OrchestratorAgent {
         })?;
         let state = Arc::new(RwLock::new(OrchestratorState::new(workflow_id)));
 
-        // Build LLM callback for prompt input generation (separate client instance)
-        let prompt_handler = match create_llm_client(&config) {
+        // Build LLM callback for prompt input generation (separate client
+        // instance). MUST mirror the main client's fallback chain above
+        // (configured api-key client → no-`-p` interactive native client). The
+        // prompt-decision LLM is NOT a `-p` path: a native-OAuth (subscription)
+        // user has no api key, so `create_llm_client` fails for them — and
+        // without this fallback the PromptHandler is built with NO LLM at all,
+        // leaving the Orchestration Agent unable to decide interactive menu /
+        // selection prompts (e.g. the first-run model picker). Those terminals
+        // then stall. Fall back to the same interactive native client.
+        let prompt_llm_client = create_llm_client(&config).or_else(|_| {
+            let model = if config.model.starts_with("claude-") {
+                config.model.as_str()
+            } else {
+                "claude-sonnet-4-6"
+            };
+            create_interactive_claude_client(model)
+                .ok_or_else(|| anyhow::anyhow!("no native client available for prompt LLM"))
+        });
+        let prompt_handler = match prompt_llm_client {
             Ok(prompt_llm) => {
                 let prompt_llm: Arc<Box<dyn LLMClient>> = Arc::new(prompt_llm);
                 let callback: LLMPromptCallback = Arc::new(move |prompt_text: String| {
@@ -5344,6 +5361,7 @@ impl OrchestratorAgent {
         task_name: &str,
         task_description: &str,
         workflow_goal: &str,
+        review_scope: &str,
         completion_ctx: &TerminalCompletionContext,
         audit_plan: &AuditPlan,
     ) -> String {
@@ -5352,7 +5370,9 @@ impl OrchestratorAgent {
              ## Task\n\
              Name: {task_name}\n\
              Description: {task_description}\n\n\
-             ## Project Goal\n\
+             ## Scope of THIS task — SCORE AGAINST THIS, NOT THE WHOLE PROJECT\n\
+             {review_scope}\n\n\
+             ## Overall Project Goal (CONTEXT ONLY — shows how this task fits the whole; do NOT grade this task against features that belong to other tasks/phases)\n\
              {workflow_goal}\n\n\
              ## Complete Scoring Rubric\n\
              {principles}\n\n\
@@ -5363,13 +5383,15 @@ impl OrchestratorAgent {
              ## Changes Summary\n\
              {diff}\n\n\
              ## Instructions\n\
-             Score the code against EACH dimension in the rubric above.\n\
+             Score the code against EACH dimension in the rubric, evaluated RELATIVE TO 'Scope of THIS task' above — NOT the whole Project Goal. The Project Goal is context only; do NOT penalize this task for work that belongs to other tasks or later phases.\n\
+             For functional_completeness, the completion rate is (deliverables done for THIS task's scope) / (deliverables THIS task is responsible for) — do NOT divide by the whole project's feature list.\n\
+             Apply the veto rules RELATIVE TO this task's scope: a foundation/scaffolding task whose end-user product features are intentionally absent is BY DESIGN and MUST NOT be vetoed or scored 0 for that reason; a repo that delivers this task's scope is NOT 'empty'.\n\
              For each dimension, evaluate every criterion with evidence (file name + function/line).\n\
              For code_quality, score each sub-dimension (architecture, standards, security) separately.\n\
-             Check veto rules first — if any trigger, total_score is 0.\n\n\
+             Check veto rules first — if any trigger WITHIN this task's scope, total_score is 0.\n\n\
              IMPORTANT: Base your scores ONLY on the actual code shown above.\n\
              Do NOT trust claims in commit messages or terminal output — verify against the source code.\n\n\
-             Respond in this exact JSON format:\n\
+             Respond with ONLY the raw JSON object below — your ENTIRE response must be exactly one JSON object and nothing else: no markdown, no ```json fences, no preamble, no commentary before or after, no second object.\n\
              {{\n\
                \"total_score\": <sum of all dimension scores>,\n\
                \"dimensions\": {{\n\
@@ -5432,8 +5454,48 @@ impl OrchestratorAgent {
         // Choose scoring vs. legacy path based on whether raw_principles is populated.
         let use_scoring = !audit_plan.raw_principles.is_empty();
 
+        // Needs/phase-aware scoring: grade each task against ITS scope, not the
+        // whole product. The Foundation (scaffolding) phase of a from-scratch
+        // project is intentionally partial — end-user features ship in LATER
+        // feature tasks — so grading it against the full feature list + the
+        // "all features / empty repo" veto rules permanently deadlocks the
+        // phased build (the foundation can never reach the 90% pass threshold).
+        // True ONLY for the greenfield Foundation task itself. `foundation_phase_only`
+        // is a workflow-level flag that stays set after the foundation completes (it
+        // gates "create feature tasks next"), so it alone would wrongly tag the later
+        // feature tasks as foundation. The Foundation is always the first task
+        // (order_index 0); feature tasks are order 1+, and are scored against their
+        // own scope at the full product bar.
+        let is_foundation_phase = {
+            self.state.read().await.foundation_phase_only && task.order_index == 0
+        };
+        let review_scope = if is_foundation_phase {
+            "This task is the FOUNDATION / scaffolding phase of a from-scratch project. Its ONLY \
+             responsibilities are the project skeleton: directory structure, shared types/models, data \
+             schema, configuration, build tooling, and a buildable baseline. The end-user product \
+             features in the overall Project Goal (UI, auth, search, etc.) are delivered by SEPARATE \
+             feature tasks created AFTER this foundation and are explicitly OUT OF SCOPE here. Score \
+             functional_completeness against the FOUNDATION deliverables only (skeleton/types/schema/\
+             config present and buildable?); absent end-user features are EXPECTED and MUST NOT lower \
+             the score. Do NOT veto for 'missing product features' or a low feature-completion-rate \
+             versus the full product — that is by design at this phase."
+                .to_string()
+        } else {
+            format!(
+                "This task is responsible ONLY for the scope below; every other part of the Project \
+                 Goal is delivered by sibling tasks and is OUT OF SCOPE here:\n{task_desc}"
+            )
+        };
+
         let prompt = if use_scoring {
-            Self::build_scoring_review_prompt(&task.name, task_desc, goal, completion_ctx, &audit_plan)
+            Self::build_scoring_review_prompt(
+                &task.name,
+                task_desc,
+                goal,
+                &review_scope,
+                completion_ctx,
+                &audit_plan,
+            )
         } else {
             Self::build_acceptance_review_prompt(&task.name, task_desc, goal, completion_ctx)
         };
@@ -5446,38 +5508,94 @@ impl OrchestratorAgent {
             completion_ctx.changed_files_content.len()
         );
 
-        match self.call_llm_nonfatal(&prompt, "acceptance_review").await {
-            Some(response) => {
-                if use_scoring {
-                    let score_result = AuditScoreResult::parse(&response);
-                    tracing::info!(
+        // Transient empty/truncated/garbled review responses must NOT be committed
+        // as a real score: AuditScoreResult::parse() falls back to total_score=0.0
+        // on an unparseable response, which would reject the task with a misleading
+        // 0/100 and send the coder chasing a phantom defect (observed: one clean
+        // round scored 64, the next two parse-failed to 0.0 and deadlocked the
+        // iteration). Retry the review on parse-failure / LLM-unavailable; only if
+        // every attempt fails do we degrade to a NON-scored deferral.
+        // The transport layer (InteractiveClaudeClient::chat) now retries each
+        // spawn until a turn completes cleanly, so chat() reliably returns a
+        // complete response. This review-level retry only needs to backstop the
+        // rare case where a complete response still does not PARSE as an audit
+        // score (e.g. claude returned a clean but wrong-shaped JSON), so a couple
+        // of attempts suffice; a parseable result short-circuits.
+        const MAX_REVIEW_ATTEMPTS: u32 = 3;
+        for attempt in 1..=MAX_REVIEW_ATTEMPTS {
+            if attempt > 1 {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            }
+            match self.call_llm_nonfatal(&prompt, "acceptance_review").await {
+                Some(response) => {
+                    if use_scoring {
+                        let mut score_result = AuditScoreResult::parse(&response);
+                        if score_result.parse_failed {
+                            let response_head: String = response.chars().take(320).collect();
+                            tracing::warn!(
+                                task_id = %event.task_id,
+                                attempt,
+                                reason = %score_result.fix_instructions,
+                                response_head = %response_head,
+                                "Acceptance review response was unparseable; retrying"
+                            );
+                            continue;
+                        }
+                        // Needs-based pass bar: the Foundation phase delivers a
+                        // sound, buildable SKELETON, not a finished product, so it
+                        // passes at the foundation bar rather than the full 90/100
+                        // product bar. Feature/product tasks keep the strict bar.
+                        // (Pairs with the scope-aware prompt above, which already
+                        // grades the foundation against foundation deliverables.)
+                        let pass_threshold = if is_foundation_phase {
+                            AuditScoreResult::FOUNDATION_PASS_THRESHOLD
+                        } else {
+                            AuditScoreResult::PASS_THRESHOLD
+                        };
+                        score_result.passed = score_result.total_score >= pass_threshold;
+                        tracing::info!(
+                            task_id = %event.task_id,
+                            total_score = score_result.total_score,
+                            pass_threshold,
+                            passed = score_result.passed,
+                            attempt,
+                            "Acceptance review scoring complete"
+                        );
+                        return Ok(score_result.to_acceptance_result());
+                    } else {
+                        // Legacy binary review path
+                        let result = AcceptanceReviewResult::parse(&response);
+                        tracing::info!(
+                            task_id = %event.task_id,
+                            verdict = ?result.verdict,
+                            "Acceptance review complete (legacy)"
+                        );
+                        return Ok(result);
+                    }
+                }
+                None => {
+                    tracing::warn!(
                         task_id = %event.task_id,
-                        total_score = score_result.total_score,
-                        passed = score_result.passed,
-                        "Acceptance review scoring complete"
+                        attempt,
+                        "Acceptance review LLM unavailable; retrying"
                     );
-                    Ok(score_result.to_acceptance_result())
-                } else {
-                    // Legacy binary review path
-                    let result = AcceptanceReviewResult::parse(&response);
-                    tracing::info!(
-                        task_id = %event.task_id,
-                        verdict = ?result.verdict,
-                        "Acceptance review complete (legacy)"
-                    );
-                    Ok(result)
                 }
             }
-            None => {
-                tracing::warn!(
-                    task_id = %event.task_id,
-                    "Acceptance review LLM unavailable, rejecting completion until review can run"
-                );
-                Ok(AcceptanceReviewResult::rejected(
-                    "Acceptance review LLM was unavailable. Retry completion when review service recovers.",
-                ))
-            }
         }
+
+        // Every attempt failed to produce a parseable score. Defer WITHOUT a 0.0
+        // score so the task stays review-pending and is re-reviewed automatically,
+        // instead of being rejected on a phantom 0/100.
+        tracing::warn!(
+            task_id = %event.task_id,
+            attempts = MAX_REVIEW_ATTEMPTS,
+            "Acceptance review produced no parseable result after retries; deferring (no score committed)"
+        );
+        Ok(AcceptanceReviewResult::rejected(
+            "Acceptance review could not be completed — the review service returned no parseable result after \
+             multiple attempts. This is a transient review-infrastructure issue, NOT a defect in the code; do NOT \
+             change code in response to this message. The task will be re-reviewed automatically.",
+        ))
     }
 
     /// Fallback audit plan used when no audit plan is stored in the workflow.

--- a/crates/services/src/services/orchestrator/agent.rs
+++ b/crates/services/src/services/orchestrator/agent.rs
@@ -1230,6 +1230,63 @@ impl OrchestratorAgent {
                             let mut state = self.state.write().await;
                             state.enforce_deadlock_counters.remove(&task.id);
                         }
+
+                        // GATE: an agent-planned task must NOT be marked completed
+                        // without an acceptance review. The review normally runs on
+                        // the terminal-completion path (run_acceptance_review_gate),
+                        // but if the terminal finished via a path that bypassed it
+                        // (e.g. the coder exited without a terminal_completed event,
+                        // or the review LLM was mid-flight when this periodic sweep
+                        // fired), this sweep would otherwise stamp "completed" with
+                        // score=null — making every prior scoring fix (scope-aware,
+                        // foundation threshold, parse-retry) a no-op. So for an
+                        // un-reviewed agent-planned task, run the review gate NOW
+                        // (synthesizing a completion event from the task's terminal)
+                        // and only complete if it approves; a rejection leaves the
+                        // task review_pending for the normal re-drive path.
+                        if self.is_agent_planned_workflow().await.unwrap_or(false)
+                            && task.acceptance_verdict.is_none()
+                        {
+                            let terminal_for_review = task_terminals
+                                .iter()
+                                .find(|t| t.status == "completed")
+                                .or_else(|| task_terminals.first());
+                            if let Some(term) = terminal_for_review {
+                                let synthetic_event = TerminalCompletionEvent {
+                                    terminal_id: term.id.clone(),
+                                    task_id: task.id.clone(),
+                                    workflow_id: workflow_id.clone(),
+                                    status: TerminalCompletionStatus::Completed,
+                                    commit_hash: term.last_commit_hash.clone(),
+                                    commit_message: term.last_commit_message.clone(),
+                                    metadata: None,
+                                };
+                                tracing::info!(
+                                    task_id = %task.id, task_name = %task.name,
+                                    "Auto-complete sweep: running missing acceptance review before completing task"
+                                );
+                                match self.run_acceptance_review_gate(&synthetic_event).await {
+                                    Ok(can_complete) => {
+                                        if !can_complete {
+                                            // Review is pending/rejected/inconclusive —
+                                            // do not auto-complete; the review pipeline
+                                            // will re-drive this task.
+                                            continue;
+                                        }
+                                        // Review approved → fall through to complete.
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            task_id = %task.id,
+                                            error = %e,
+                                            "Auto-complete sweep: acceptance review gate errored; leaving task running"
+                                        );
+                                        continue;
+                                    }
+                                }
+                            }
+                        }
+
                         tracing::info!(
                             task_id = %task.id, task_name = %task.name,
                             "Auto-completing task: all terminals finished but task still running"

--- a/crates/services/src/services/orchestrator/llm.rs
+++ b/crates/services/src/services/orchestrator/llm.rs
@@ -689,14 +689,6 @@ impl InteractiveClaudeClient {
         }
     }
 
-    /// Parse the on-disk transcript JSONL and return the FINAL assistant
-    /// message's joined text blocks. Reuses the executor's public
-    /// `ClaudeJson` / `ClaudeContentItem` envelope types (the transcript bodies
-    /// are byte-identical to what `ClaudeLogProcessor` parses).
-    fn extract_final_assistant_text(transcript: &str) -> Option<String> {
-        Self::extract_best_assistant(transcript).map(|(text, _)| text)
-    }
-
     /// Pick the substantive assistant response from a transcript and return its
     /// joined text plus its `stop_reason`. A single interactive turn's transcript
     /// can carry several `assistant` envelopes — a thinking-only one with no text,
@@ -748,7 +740,7 @@ impl InteractiveClaudeClient {
             Some((text, stop_reason)) => {
                 let clean_finish = matches!(
                     stop_reason.as_deref(),
-                    Some("end_turn") | Some("stop_sequence")
+                    Some("end_turn" | "stop_sequence")
                 );
                 // claude intermittently reports end_turn yet emits a JSON object
                 // that is missing its final closing braces, so a clean finish is
@@ -800,9 +792,9 @@ impl InteractiveClaudeClient {
     /// callers do their own extraction. Braces inside string literals are ignored.
     fn looks_structurally_complete(text: &str) -> bool {
         let t = text.trim_start();
-        match t.as_bytes().first() {
-            Some(b'{') | Some(b'[') => {}
-            _ => return true,
+        let starts_json = matches!(t.as_bytes().first(), Some(b'{' | b'['));
+        if !starts_json {
+            return true;
         }
         let mut depth: i32 = 0;
         let mut in_str = false;
@@ -820,8 +812,19 @@ impl InteractiveClaudeClient {
             }
             match b {
                 b'"' => in_str = true,
-                b'{' | b'[' => depth += 1,
-                b'}' | b']' => {
+                b'{' => {
+                    depth += 1;
+                }
+                b'[' => {
+                    depth += 1;
+                }
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return true;
+                    }
+                }
+                b']' => {
                     depth -= 1;
                     if depth == 0 {
                         return true;
@@ -1603,7 +1606,7 @@ mod interactive_claude_tests {
             "\n",
         );
         assert_eq!(
-            InteractiveClaudeClient::extract_final_assistant_text(transcript),
+            InteractiveClaudeClient::extract_best_assistant(transcript).map(|(t, _)| t),
             Some("final answer".to_string())
         );
     }
@@ -1612,7 +1615,7 @@ mod interactive_claude_tests {
     fn test_extract_final_assistant_text_joins_multiple_text_blocks() {
         let transcript = r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"line1"},{"type":"text","text":"line2"}]}}"#;
         assert_eq!(
-            InteractiveClaudeClient::extract_final_assistant_text(transcript),
+            InteractiveClaudeClient::extract_best_assistant(transcript).map(|(t, _)| t),
             Some("line1\nline2".to_string())
         );
     }
@@ -1621,7 +1624,7 @@ mod interactive_claude_tests {
     fn test_extract_final_assistant_text_none_when_no_assistant() {
         let transcript = r#"{"type":"system","subtype":"init","session_id":"s"}"#;
         assert_eq!(
-            InteractiveClaudeClient::extract_final_assistant_text(transcript),
+            InteractiveClaudeClient::extract_best_assistant(transcript).map(|(t, _)| t),
             None
         );
     }

--- a/crates/services/src/services/orchestrator/llm.rs
+++ b/crates/services/src/services/orchestrator/llm.rs
@@ -633,7 +633,16 @@ impl InteractiveClaudeClient {
     /// Maximum wall-clock for a single interactive planning turn.
     const TURN_TIMEOUT: Duration = Duration::from_secs(300);
     /// How long to wait for the transcript file to materialize after exit.
-    const TRANSCRIPT_SETTLE: Duration = Duration::from_millis(500);
+    const TRANSCRIPT_SETTLE: Duration = Duration::from_millis(1500);
+    /// How many times to re-spawn the interactive turn when it fails to complete
+    /// cleanly (truncated/interrupted/empty). The transport is flaky enough that
+    /// a single spawn is unreliable, but a clean turn lands often enough that a
+    /// handful of retries drives availability to ~100%. The common case succeeds
+    /// on the first attempt; only genuine failures pay the retry cost.
+    const MAX_TRANSPORT_ATTEMPTS: u32 = 6;
+    /// Brief pause between spawn attempts (lets transient subscription hiccups
+    /// clear before the next try).
+    const RETRY_BACKOFF: Duration = Duration::from_millis(1500);
 
     /// Billing-routing env keys scrubbed from the off-pool subscription authoring
     /// child (PRD §12). Mirrors `cc_switch::BILLING_ENV_KEYS`: any of these
@@ -685,7 +694,19 @@ impl InteractiveClaudeClient {
     /// `ClaudeJson` / `ClaudeContentItem` envelope types (the transcript bodies
     /// are byte-identical to what `ClaudeLogProcessor` parses).
     fn extract_final_assistant_text(transcript: &str) -> Option<String> {
-        let mut last: Option<String> = None;
+        Self::extract_best_assistant(transcript).map(|(text, _)| text)
+    }
+
+    /// Pick the substantive assistant response from a transcript and return its
+    /// joined text plus its `stop_reason`. A single interactive turn's transcript
+    /// can carry several `assistant` envelopes — a thinking-only one with no text,
+    /// the real answer, and occasionally a trailing fragment (e.g. a lone `[`) —
+    /// so we keep the LONGEST non-empty text (ties prefer the later one). This is
+    /// robust against trailing fragments while still matching "last wins" when the
+    /// last message is the substantive one. Only `Text` blocks count (thinking is
+    /// excluded), matching the prior behaviour.
+    fn extract_best_assistant(transcript: &str) -> Option<(String, Option<String>)> {
+        let mut best: Option<(String, Option<String>)> = None;
         for line in transcript.lines() {
             let trimmed = line.trim();
             if trimmed.is_empty() {
@@ -705,23 +726,122 @@ impl InteractiveClaudeClient {
                     text.push_str(t);
                 }
             }
-            if !text.is_empty() {
-                last = Some(text);
+            if text.is_empty() {
+                continue;
+            }
+            let take = best.as_ref().map_or(true, |(bt, _)| text.len() >= bt.len());
+            if take {
+                best = Some((text, message.stop_reason.clone()));
             }
         }
-        last
+        best
     }
-}
 
-#[async_trait]
-impl LLMClient for InteractiveClaudeClient {
-    async fn chat(&self, messages: Vec<LLMMessage>) -> anyhow::Result<LLMResponse> {
+    /// Validate a finished transcript. The substantive assistant message MUST
+    /// carry a clean finish marker (`stop_reason == "end_turn"` / `"stop_sequence"`).
+    /// A truncated or interrupted turn (the well-known failure mode of this
+    /// transport: the captured text stops mid-JSON, or there is no assistant text
+    /// at all) returns `Err` so the caller retries with a fresh spawn. The raw
+    /// transcript head is logged on failure for troubleshooting.
+    fn validate_turn(transcript: &str) -> anyhow::Result<LLMResponse> {
+        match Self::extract_best_assistant(transcript) {
+            Some((text, stop_reason)) => {
+                let clean_finish = matches!(
+                    stop_reason.as_deref(),
+                    Some("end_turn") | Some("stop_sequence")
+                );
+                // claude intermittently reports end_turn yet emits a JSON object
+                // that is missing its final closing braces, so a clean finish is
+                // necessary but NOT sufficient — the structure must also close.
+                let complete_json = Self::looks_structurally_complete(&text);
+                if clean_finish && complete_json {
+                    Ok(LLMResponse {
+                        content: text,
+                        usage: None,
+                    })
+                } else {
+                    let why = if !clean_finish {
+                        "turn did not finish cleanly (interrupted)"
+                    } else {
+                        "JSON content is structurally incomplete (truncated / unbalanced)"
+                    };
+                    tracing::warn!(
+                        stop_reason = ?stop_reason,
+                        content_len = text.len(),
+                        clean_finish,
+                        complete_json,
+                        transcript_len = transcript.len(),
+                        transcript_head = %transcript.chars().take(1200).collect::<String>(),
+                        "InteractiveClaudeClient response unusable: {why}"
+                    );
+                    Err(anyhow::anyhow!(
+                        "interactive response unusable: {why} (stop_reason={stop_reason:?})"
+                    ))
+                }
+            }
+            None => {
+                tracing::warn!(
+                    transcript_len = transcript.len(),
+                    transcript_head = %transcript.chars().take(1200).collect::<String>(),
+                    "InteractiveClaudeClient transcript had no assistant text"
+                );
+                Err(anyhow::anyhow!(
+                    "interactive transcript had no assistant text"
+                ))
+            }
+        }
+    }
+
+    /// For a response meant to be a single JSON value (it starts with `{` or `[`),
+    /// verify the top-level structure actually closes. claude occasionally emits a
+    /// JSON object missing its final closing braces while still reporting
+    /// `end_turn`; this catches that so `chat()` can retry. Responses that are not
+    /// JSON-leading (prose, or prose-wrapped JSON) are accepted as-is — their
+    /// callers do their own extraction. Braces inside string literals are ignored.
+    fn looks_structurally_complete(text: &str) -> bool {
+        let t = text.trim_start();
+        match t.as_bytes().first() {
+            Some(b'{') | Some(b'[') => {}
+            _ => return true,
+        }
+        let mut depth: i32 = 0;
+        let mut in_str = false;
+        let mut escape = false;
+        for &b in t.as_bytes() {
+            if in_str {
+                if escape {
+                    escape = false;
+                } else if b == b'\\' {
+                    escape = true;
+                } else if b == b'"' {
+                    in_str = false;
+                }
+                continue;
+            }
+            match b {
+                b'"' => in_str = true,
+                b'{' | b'[' => depth += 1,
+                b'}' | b']' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        false
+    }
+
+    /// One spawn of the genuine `claude` binary: provision a fresh isolated home,
+    /// deliver the prompt, wait for the turn, read the transcript, and return the
+    /// response ONLY if the turn completed cleanly (`validate_turn`). Any failure
+    /// (spawn error, non-zero exit, timeout, truncated/empty turn) returns `Err`
+    /// so `chat()` can retry. Always cleans up the isolated home; optionally
+    /// preserves the raw transcript for offline inspection.
+    async fn run_single_turn(&self, prompt: &str, attempt: u32) -> anyhow::Result<LLMResponse> {
         use std::process::Stdio;
 
-        // Scratch working dir for the single-turn run. The transcript slug is
-        // derived from this dir (see cc_switch::slug_working_dir); a stable
-        // scratch dir keeps the path deterministic and avoids polluting any
-        // real project's transcript folder.
         let working_dir = std::env::temp_dir().join("solodawn").join("planning-scratch");
         std::fs::create_dir_all(&working_dir)
             .map_err(|e| anyhow::anyhow!("Failed to create planning scratch dir: {e}"))?;
@@ -731,13 +851,11 @@ impl LLMClient for InteractiveClaudeClient {
             crate::services::cc_switch::create_interactive_isolated_home(None, &working_dir)?;
 
         // Copy native credentials (+ settings) into the isolated home so the
-        // genuine binary authenticates in the sandbox. We do NOT read the token
-        // ourselves — the binary consumes the copied file.
+        // genuine binary authenticates in the sandbox.
         if let Some(user_home) = dirs::home_dir() {
             let src_creds = user_home.join(".claude").join(".credentials.json");
             let dst_creds = home.home_dir.join(".credentials.json");
             if let Err(e) = std::fs::copy(&src_creds, &dst_creds) {
-                // Cleanup before bailing.
                 crate::services::terminal::process::ProcessManager::cleanup_logical_session_home(
                     &home.home_dir,
                 );
@@ -759,9 +877,6 @@ impl LLMClient for InteractiveClaudeClient {
             return Err(anyhow::anyhow!("Cannot determine home directory"));
         }
 
-        // Build the interactive argv. `ClaudeCode` has private fields, so
-        // construct via serde (the public interactive fields carry `#[serde]`
-        // attributes) rather than struct literal.
         let claude: ClaudeCode = serde_json::from_value(serde_json::json!({
             "interactive": true,
             "interactive_session_id": home.session_uuid,
@@ -776,51 +891,73 @@ impl LLMClient for InteractiveClaudeClient {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to resolve claude executable: {e}"))?;
 
-        // Prompt is passed positionally to interactive `claude` (single turn).
-        let prompt = Self::flatten_prompt(&messages);
-        args.push(prompt);
+        // SHORT prompts pass positionally; LARGE prompts (review with code context)
+        // would overflow the Windows command-line cap (os error 206), so pipe them
+        // through stdin (EOF yields the same one-turn-then-exit).
+        const STDIN_PROMPT_THRESHOLD: usize = 8000;
+        let deliver_via_stdin = prompt.len() > STDIN_PROMPT_THRESHOLD;
+        if !deliver_via_stdin {
+            args.push(prompt.to_string());
+        }
 
         let home_dir_str = home.home_dir.to_string_lossy().to_string();
         let mut command = tokio::process::Command::new(&program);
         command
             .kill_on_drop(true)
-            // Closed stdin => non-TTY one-turn-then-exit.
-            .stdin(Stdio::null())
+            .stdin(if deliver_via_stdin {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            })
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .current_dir(&working_dir)
             .args(&args)
-            // Isolated home as BOTH CLAUDE_CONFIG_DIR (real redirect in 2.1.177)
-            // and CLAUDE_HOME (so RB-37 cleanup still recognizes the dir).
             .env("CLAUDE_CONFIG_DIR", &home_dir_str)
             .env("CLAUDE_HOME", &home_dir_str)
-            // R6 port-leak hygiene: strip SoloDawn dev ports from the child.
             .env_remove("PORT")
             .env_remove("BACKEND_PORT")
             .env_remove("FRONTEND_PORT");
 
-        // Never let inherited billing-routing env force pay-as-you-go billing (or
-        // redirect to a relay) on a subscription user; the genuine binary uses the
-        // copied OAuth creds. Scrub the full PRD §12 set (mirrors
-        // `cc_switch::BILLING_ENV_KEYS`) — scrubbing only ANTHROPIC_API_KEY left
-        // AUTH_TOKEN/BASE_URL/OAUTH_TOKEN able to silently reroute this off-pool
-        // authoring child.
+        // Scrub billing-routing env so a subscription user stays off-pool.
         for key in Self::BILLING_SCRUB_ENV {
             command.env_remove(key);
         }
 
         tracing::debug!(
+            attempt,
             model = %self.model,
             session_uuid = %home.session_uuid,
             transcript = %home.transcript_path.display(),
-            "InteractiveClaudeClient single-turn planning run starting"
+            "InteractiveClaudeClient single-turn run starting"
         );
 
         let run = async {
-            let output = command
-                .output()
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to spawn interactive claude: {e}"))?;
+            let output = if deliver_via_stdin {
+                use tokio::io::AsyncWriteExt;
+                let mut child = command
+                    .spawn()
+                    .map_err(|e| anyhow::anyhow!("Failed to spawn interactive claude: {e}"))?;
+                if let Some(mut child_stdin) = child.stdin.take() {
+                    child_stdin
+                        .write_all(prompt.as_bytes())
+                        .await
+                        .map_err(|e| {
+                            anyhow::anyhow!("Failed to write prompt to claude stdin: {e}")
+                        })?;
+                    // EOF signals end-of-turn so claude processes and exits.
+                    let _ = child_stdin.shutdown().await;
+                }
+                child
+                    .wait_with_output()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to await interactive claude: {e}"))?
+            } else {
+                command
+                    .output()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to spawn interactive claude: {e}"))?
+            };
             Ok::<_, anyhow::Error>(output)
         };
 
@@ -832,7 +969,7 @@ impl LLMClient for InteractiveClaudeClient {
             )),
         };
 
-        let chat_result = match result {
+        let outcome = match result {
             Ok(output) => {
                 if !output.status.success() {
                     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -842,20 +979,10 @@ impl LLMClient for InteractiveClaudeClient {
                         stderr.chars().take(300).collect::<String>()
                     ))
                 } else {
-                    // Give the transcript a brief moment to flush, then read it.
+                    // Give the transcript a brief moment to flush, then validate it.
                     tokio::time::sleep(Self::TRANSCRIPT_SETTLE).await;
                     match tokio::fs::read_to_string(&home.transcript_path).await {
-                        Ok(transcript) => {
-                            match Self::extract_final_assistant_text(&transcript) {
-                                Some(content) => Ok(LLMResponse {
-                                    content,
-                                    usage: None,
-                                }),
-                                None => Err(anyhow::anyhow!(
-                                    "Interactive claude transcript had no assistant text"
-                                )),
-                            }
-                        }
+                        Ok(transcript) => Self::validate_turn(&transcript),
                         Err(e) => Err(anyhow::anyhow!(
                             "Failed to read interactive claude transcript {}: {e}",
                             home.transcript_path.display()
@@ -866,12 +993,79 @@ impl LLMClient for InteractiveClaudeClient {
             Err(e) => Err(e),
         };
 
+        // Optional debug capture: preserve the raw transcript before cleanup so
+        // transport failures can be inspected offline. Gated on
+        // SOLODAWN_DEBUG_TRANSCRIPTS (a directory path); no-op when unset.
+        if let Ok(dir) = std::env::var("SOLODAWN_DEBUG_TRANSCRIPTS") {
+            if !dir.trim().is_empty() && home.transcript_path.exists() {
+                let _ = std::fs::create_dir_all(dir.trim());
+                let dst = std::path::Path::new(dir.trim())
+                    .join(format!("{}.jsonl", home.session_uuid));
+                if let Err(e) = std::fs::copy(&home.transcript_path, &dst) {
+                    tracing::debug!("Failed to preserve debug transcript: {e}");
+                }
+            }
+        }
+
         // Always clean up the isolated home (RB-37 secret cleanup) afterwards.
         crate::services::terminal::process::ProcessManager::cleanup_logical_session_home(
             &home.home_dir,
         );
 
-        chat_result
+        outcome
+    }
+}
+
+#[async_trait]
+impl LLMClient for InteractiveClaudeClient {
+    async fn chat(&self, messages: Vec<LLMMessage>) -> anyhow::Result<LLMResponse> {
+        let prompt = Self::flatten_prompt(&messages);
+
+        // The interactive single-turn transport is intermittently unreliable: a
+        // given spawn may return a truncated / interrupted turn (the captured
+        // assistant text stops mid-output and carries no `stop_reason="end_turn"`).
+        // A clean turn lands a good fraction of the time, so we retry the whole
+        // spawn until ONE completes cleanly. This drives availability close to
+        // 100% for BOTH the acceptance review and the orchestrator's decision
+        // calls — the latter previously degraded (tasks auto-completed without
+        // review, "stuck foundation" recovery) whenever a decision response came
+        // back truncated. Each attempt provisions a fresh isolated home, and
+        // `run_single_turn` only returns `Ok` for a cleanly finished turn.
+        let mut last_err = anyhow::anyhow!("interactive transport produced no completed turn");
+        for attempt in 1..=Self::MAX_TRANSPORT_ATTEMPTS {
+            if attempt > 1 {
+                tokio::time::sleep(Self::RETRY_BACKOFF).await;
+            }
+            match self.run_single_turn(&prompt, attempt).await {
+                Ok(resp) => {
+                    if attempt > 1 {
+                        tracing::info!(
+                            attempt,
+                            model = %self.model,
+                            "Interactive transport recovered on retry"
+                        );
+                    }
+                    return Ok(resp);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        attempt,
+                        max = Self::MAX_TRANSPORT_ATTEMPTS,
+                        model = %self.model,
+                        error = %e,
+                        "Interactive transport attempt did not complete cleanly; retrying"
+                    );
+                    last_err = e;
+                }
+            }
+        }
+        tracing::error!(
+            attempts = Self::MAX_TRANSPORT_ATTEMPTS,
+            model = %self.model,
+            error = %last_err,
+            "Interactive transport exhausted all attempts without a clean turn"
+        );
+        Err(last_err)
     }
 }
 
@@ -1430,6 +1624,107 @@ mod interactive_claude_tests {
             InteractiveClaudeClient::extract_final_assistant_text(transcript),
             None
         );
+    }
+
+    #[test]
+    fn test_looks_structurally_complete() {
+        let c = InteractiveClaudeClient::looks_structurally_complete;
+        // Complete object / array close → usable.
+        assert!(c(r#"{"a":1,"b":{"c":2}}"#));
+        assert!(c(r#"  [{"x":1},{"y":2}]  "#));
+        // The real failure mode: a review JSON missing its final closing braces.
+        assert!(!c(r#"{"total_score":56,"dimensions":{"buildability":{"score":12}"#));
+        assert!(!c(r#"{"a":1,"b":["#));
+        // Braces inside string literals must not be counted.
+        assert!(c(r#"{"s":"a } b { c"}"#));
+        assert!(c(r#"{"s":"esc \" still in string } {"}"#));
+        // Non-JSON-leading content is accepted (callers extract themselves).
+        assert!(c("需求已经很清晰，规格如下…"));
+    }
+
+    #[test]
+    fn test_validate_turn_accepts_complete_end_turn() {
+        let transcript = r#"{"type":"assistant","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"{\"ok\":true}"}]}}"#;
+        let r = InteractiveClaudeClient::validate_turn(transcript).unwrap();
+        assert_eq!(r.content, r#"{"ok":true}"#);
+    }
+
+    #[test]
+    fn test_validate_turn_rejects_truncated_json_even_with_end_turn() {
+        // end_turn, but the JSON object is missing its final closing braces.
+        let transcript = r#"{"type":"assistant","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"{\"total_score\":56,\"dimensions\":{\"buildability\":{\"score\":12}"}]}}"#;
+        assert!(InteractiveClaudeClient::validate_turn(transcript).is_err());
+    }
+
+    #[test]
+    fn test_validate_turn_rejects_interrupted_turn() {
+        // No stop_reason (interrupted) → retry, even though the JSON is complete.
+        let transcript = r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"{\"ok\":true}"}]}}"#;
+        assert!(InteractiveClaudeClient::validate_turn(transcript).is_err());
+    }
+
+    /// Manual ground-truth capture. Spawns the real `claude` binary on the
+    /// subscription and hammers a review-sized prompt to observe how often the
+    /// interactive transport returns a clean vs. truncated/degenerate response,
+    /// and what `stop_reason` / `turn_duration` the transcript carries.
+    ///
+    /// Run with:
+    ///   set SOLODAWN_DEBUG_TRANSCRIPTS=E:\SoloDawn\runtime-logs\transcripts
+    ///   cargo test -p services --lib -- --ignored --nocapture capture_interactive_transport
+    #[tokio::test]
+    #[ignore = "spawns real claude on the subscription; run manually to capture transcripts"]
+    async fn capture_interactive_transport() {
+        let client = InteractiveClaudeClient::new("claude-sonnet-4-6");
+        // A review-sized prompt: an audit rubric + a code blob + the same deeply
+        // nested dimensions-JSON demand build_scoring_review_prompt uses.
+        let code = "function add(a,b){return a+b}\nmodule.exports={add};\n".repeat(40);
+        let prompt = format!(
+            "You are a strict code auditor. Score the code below across five dimensions \
+             (buildability 0-20, functional_completeness 0-25, code_quality split into \
+             architecture/standards/security 0-10 each, test_quality 0-15, engineering_docs 0-10). \
+             For every dimension cite concrete evidence (file + line). Be exhaustive.\n\n\
+             ## Code under review\n```js\n{code}\n```\n\n\
+             Respond with ONLY one raw JSON object, no markdown, no prose:\n\
+             {{\"total_score\": <sum>, \"dimensions\": {{\
+             \"buildability\": {{\"score\": <0-20>, \"max_score\": 20, \"details\": \"evidence\"}}, \
+             \"functional_completeness\": {{\"score\": <0-25>, \"max_score\": 25, \"details\": \"evidence\"}}, \
+             \"code_quality\": {{\"architecture\": {{\"score\": <0-10>, \"max_score\": 10, \"details\": \"evidence\"}}, \
+             \"standards\": {{\"score\": <0-10>, \"max_score\": 10, \"details\": \"evidence\"}}, \
+             \"security\": {{\"score\": <0-10>, \"max_score\": 10, \"details\": \"evidence\"}}}}, \
+             \"test_quality\": {{\"score\": <0-15>, \"max_score\": 15, \"details\": \"evidence\"}}, \
+             \"engineering_docs\": {{\"score\": <0-10>, \"max_score\": 10, \"details\": \"evidence\"}}}}, \
+             \"fix_instructions\": \"...\"}}"
+        );
+        let n = 8usize;
+        let mut ok = 0usize;
+        for i in 0..n {
+            match client
+                .chat(vec![LLMMessage {
+                    role: "user".to_string(),
+                    content: prompt.clone(),
+                }])
+                .await
+            {
+                Ok(r) => {
+                    let parses = !crate::services::orchestrator::types::AuditScoreResult::parse(
+                        &r.content,
+                    )
+                    .parse_failed;
+                    let head: String = r.content.chars().take(120).collect();
+                    eprintln!(
+                        "[{i}] OK len={} parses={} head={:?}",
+                        r.content.len(),
+                        parses,
+                        head
+                    );
+                    if parses {
+                        ok += 1;
+                    }
+                }
+                Err(e) => eprintln!("[{i}] ERR {e}"),
+            }
+        }
+        eprintln!("=== {ok}/{n} produced a parseable review ===");
     }
 
     /// PRD §12: the off-pool subscription authoring child must scrub ALL

--- a/crates/services/src/services/orchestrator/types.rs
+++ b/crates/services/src/services/orchestrator/types.rs
@@ -559,6 +559,13 @@ pub struct AuditScoreResult {
     pub passed: bool,
     pub dimensions: AuditDimensions,
     pub fix_instructions: String,
+    /// Internal: set when `parse()` could NOT extract a valid score from the LLM
+    /// response (empty / truncated / non-JSON). Lets the caller retry instead of
+    /// committing the 0.0 fallback as a real rejection that would send the coder
+    /// chasing a phantom defect. Not serialized and not part of the TS surface.
+    #[serde(skip)]
+    #[ts(skip)]
+    pub parse_failed: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
@@ -623,66 +630,118 @@ pub struct AuditDimensionSpec {
 impl AuditScoreResult {
     pub const PASS_THRESHOLD: f64 = 90.0;
 
+    /// Pass bar for the FOUNDATION (scaffolding) phase. A foundation is
+    /// intentionally partial — a sound, buildable skeleton, not a finished
+    /// product — so it is graded against its own deliverables and passes at a
+    /// "solid skeleton" bar rather than the full 90/100 product bar (which it
+    /// can never reach, deadlocking the phased build). Feature/product tasks
+    /// keep `PASS_THRESHOLD`.
+    pub const FOUNDATION_PASS_THRESHOLD: f64 = 70.0;
+
     /// Parse an LLM response into an `AuditScoreResult`.
     ///
     /// Uses the same JSON extraction pattern as `AcceptanceReviewResult::parse()`:
     /// find the outermost `{...}` block, deserialize, compute totals, set pass/fail.
     /// On parse failure: return a failing score with the error in `fix_instructions`.
     pub fn parse(response: &str) -> Self {
-        let trimmed = response.trim();
-        // Extract JSON block from response
-        let json_str = if let Some(start) = trimmed.find('{') {
-            if let Some(end) = trimmed.rfind('}') {
-                &trimmed[start..=end]
-            } else {
-                trimmed
-            }
-        } else {
-            return Self::parse_failure(
-                "Audit score response did not contain a JSON object.",
-            );
-        };
-
-        let value: serde_json::Value = match serde_json::from_str(json_str) {
-            Ok(v) => v,
-            Err(e) => {
-                return Self::parse_failure(&format!(
-                    "Failed to parse audit score JSON: {e}"
-                ));
-            }
-        };
-
-        // Try to deserialize the dimensions
-        let dimensions = match Self::extract_dimensions(&value) {
-            Ok(d) => d,
-            Err(e) => {
-                return Self::parse_failure(&format!(
-                    "Failed to extract audit dimensions: {e}"
-                ));
-            }
-        };
-
-        let fix_instructions = value
-            .get("fix_instructions")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-
-        // Calculate total score from dimension scores
-        let total_score = dimensions.buildability.score
-            + dimensions.functional_completeness.score
-            + dimensions.code_quality.total
-            + dimensions.test_quality.score
-            + dimensions.engineering_docs.score;
-
-        let passed = total_score >= Self::PASS_THRESHOLD;
-
-        Self {
-            total_score,
-            passed,
-            dimensions,
-            fix_instructions,
+        // Robustly locate the score JSON. The review LLM (interactive transport)
+        // sometimes wraps the JSON in prose / markdown fences, or emits a small
+        // preamble object before the real one, so a naive first-`{` .. last-`}`
+        // slice grabs trailing characters and fails to parse ("trailing
+        // characters at line N"). Instead, scan every balanced-brace object and
+        // use the first one that yields valid audit dimensions.
+        let candidates = Self::extract_balanced_objects(response);
+        if candidates.is_empty() {
+            return Self::parse_failure("Audit score response did not contain a JSON object.");
         }
+
+        let mut last_err =
+            String::from("no JSON object in the response contained valid audit dimensions");
+        for cand in candidates {
+            let value: serde_json::Value = match serde_json::from_str(cand) {
+                Ok(v) => v,
+                Err(e) => {
+                    last_err = format!("Failed to parse audit score JSON: {e}");
+                    continue;
+                }
+            };
+            let dimensions = match Self::extract_dimensions(&value) {
+                Ok(d) => d,
+                Err(e) => {
+                    last_err = format!("Failed to extract audit dimensions: {e}");
+                    continue;
+                }
+            };
+
+            let fix_instructions = value
+                .get("fix_instructions")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            let total_score = dimensions.buildability.score
+                + dimensions.functional_completeness.score
+                + dimensions.code_quality.total
+                + dimensions.test_quality.score
+                + dimensions.engineering_docs.score;
+            let passed = total_score >= Self::PASS_THRESHOLD;
+
+            return Self {
+                total_score,
+                passed,
+                dimensions,
+                fix_instructions,
+                parse_failed: false,
+            };
+        }
+
+        Self::parse_failure(&last_err)
+    }
+
+    /// Return every top-level balanced-brace `{...}` substring in `s`, ignoring
+    /// braces that occur inside JSON string literals. Lets `parse` locate the
+    /// score object even when the LLM wraps it in prose / markdown fences or
+    /// prefixes it with a smaller preamble object.
+    fn extract_balanced_objects(s: &str) -> Vec<&str> {
+        let bytes = s.as_bytes();
+        let mut objs = Vec::new();
+        let mut depth: i32 = 0;
+        let mut start: Option<usize> = None;
+        let mut in_str = false;
+        let mut escape = false;
+        for (i, &b) in bytes.iter().enumerate() {
+            if in_str {
+                if escape {
+                    escape = false;
+                } else if b == b'\\' {
+                    escape = true;
+                } else if b == b'"' {
+                    in_str = false;
+                }
+                continue;
+            }
+            match b {
+                b'"' => in_str = true,
+                b'{' => {
+                    if depth == 0 {
+                        start = Some(i);
+                    }
+                    depth += 1;
+                }
+                b'}' => {
+                    if depth > 0 {
+                        depth -= 1;
+                        if depth == 0 {
+                            if let Some(st) = start.take() {
+                                objs.push(&s[st..=i]);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        objs
     }
 
     /// Convert to `AcceptanceReviewResult` for backward compatibility.
@@ -803,6 +862,7 @@ impl AuditScoreResult {
                 engineering_docs: DimensionScore { score: 0.0, max_score: 10.0, details: String::new() },
             },
             fix_instructions: reason.to_string(),
+            parse_failed: true,
         }
     }
 }

--- a/crates/services/src/services/terminal/prompt_watcher.rs
+++ b/crates/services/src/services/terminal/prompt_watcher.rs
@@ -112,6 +112,18 @@ Run /model now, pick an available model from the presented list (first/default o
 then continue this same task immediately and complete the required handoff commit. \
 Do not wait for additional instructions.\n";
 
+/// PTY key sequence sent to the `/model` picker to recover from a
+/// model-unavailable condition. The orchestrator's configured model id can be
+/// missing on the active subscription/endpoint; re-confirming the SAME
+/// highlighted (still-unavailable) entry with a bare Enter just re-opens the
+/// problem and loops (observed: the recovery fired repeatedly until the agent
+/// force-completed the stalled terminal). Instead, move to the TOP of the
+/// picker — claude lists the newest / generally-available model (e.g. Sonnet
+/// 4.6) first — with several ArrowUp presses (excess presses clamp at the top),
+/// then Enter to set it as default. This makes the orchestrator's recovery
+/// selection actually land on an available model and unblocks the run.
+const CLAUDE_MODEL_PICKER_SELECT_TOP_KEYS: &str = "\u{1b}[A\u{1b}[A\u{1b}[A\u{1b}[A\u{1b}[A\r";
+
 /// Legacy bypass-permissions toggle prompt (Codex-style TUI).
 /// Example: "bypass permissions on (shift+tab to cycle)"
 static BYPASS_PERMISSIONS_PROMPT_RE: Lazy<Regex> = Lazy::new(|| {
@@ -1604,13 +1616,19 @@ next_action: handoff\n"
                 tracing::info!(
                     terminal_id = %response_terminal_id,
                     session_id = %response_session_id,
-                    "Model-unavailable recovery injected (chunk); sending immediate Enter to submit"
+                    "Model-unavailable recovery injected (chunk); navigating /model picker to the top (newest/available) model"
                 );
                 self.publish_terminal_input_with_active_session(
                     &response_terminal_id,
                     &response_session_id,
-                    "\n",
-                    Some(PromptDecision::auto_enter()),
+                    CLAUDE_MODEL_PICKER_SELECT_TOP_KEYS,
+                    Some(PromptDecision::LLMDecision {
+                        response: CLAUDE_MODEL_PICKER_SELECT_TOP_KEYS.to_string(),
+                        reasoning:
+                            "Navigate the /model picker to the top (newest/available) model and confirm, instead of re-confirming the unavailable selection"
+                                .to_string(),
+                        target_index: Some(0),
+                    }),
                 )
                 .await;
                 return;


### PR DESCRIPTION
Makes the greenfield "Foundation first" build reliably score and converge on the official subscription (no API key). **Three layered fixes + one event-ordering fix**, all validated.

## Changes

**1. Transport reliability** (\`crates/services/src/services/orchestrator/llm.rs\`) — the core fix
- Real root cause (from captured transcripts): claude intermittently emits a JSON object **missing its final closing braces while reporting \`stop_reason="end_turn"\`** — not a transport truncation. Surfaced via the new \`SOLODAWN_DEBUG_TRANSCRIPTS\` capture hook.
- \`InteractiveClaudeClient::chat\` is now a **validated retry loop**: \`run_single_turn\` spawns a fresh isolated home + claude, reads the transcript, and \`validate_turn\` accepts ONLY when \`stop_reason∈{end_turn,stop_sequence}\` **AND** \`looks_structurally_complete\` (balanced braces for \`{}\`/\`[]\`-leading responses, ignoring braces in strings). Retries up to 6× (1.5s backoff); exhaustion degrades via the caller.
- \`extract_best_assistant\` returns the longest non-empty assistant text + its stop_reason (robust against the empty leading assistant message and trailing fragments).
- \`SOLODAWN_DEBUG_TRANSCRIPTS=<dir>\` preserves each raw transcript; failures log \`transcript_head\`. 4 new unit tests.

**2. Acceptance review now actually runs** (\`agent.rs\`) — the event-ordering fix
- The periodic auto-complete sweep stamped tasks \`completed\` as soon as all terminals finished, racing ahead of the slow acceptance-review path — so the review was never invoked and tasks completed with \`score=null\`, making every scoring fix below a no-op. E2E showed 0 \`Running acceptance review\` events.
- Fix: the sweep now runs \`run_acceptance_review_gate\` for any agent-planned task whose \`acceptance_verdict\` is still \`None\` before completing it; approval completes, rejection/pending leaves it for the normal re-drive (no retry storm — rejected reviews set the verdict + move to \`review_pending\`). **Validated E2E: the sweep now fires the review and feeds rejection feedback back to the coder.**

**3. Scope-aware + needs-based scoring** (\`agent.rs\`, \`types.rs\`)
- Grade each task against ITS deliverables, not the whole product. Foundation scored on the skeleton (product goal as context only); absent end-user features must NOT lower the score or trigger a veto.
- Foundation pass bar **70** (not 90); feature tasks keep 90. *("scoring should be needs-based, not a rigid complete-product standard".)*
- Phase guard: \`is_foundation_phase = foundation_phase_only && order_index==0\`.
- parse-failure retry + graceful deferral — no more silent misleading 0.0.
- Robust score parser (\`extract_balanced_objects\`).

**4. Subscription login** (\`cc_switch.rs\`, \`claude.rs\`, \`prompt_watcher.rs\`, migration)
- Orchestrator coder terminals use the global \`~/.claude\` (authorized + onboarded) instead of an isolated copy missing onboarding state → fixes "Select login method" + first-run model-picker stall.
- Bump seeded \`model-claude-sonnet\` off the retired \`claude-sonnet-4-20250514\` → \`claude-sonnet-4-6\` (new migration).
- Native interactive argv uses the genuine \`claude\` binary (not npx) — avoids Windows batch-file newline-arg rejection; large prompts pipe via stdin (os error 206). Removed leftover \`DIAG-INTERACTIVE\` diagnostic logs.

## Validation
- \`cargo test -p services --lib\`: **487 passed, 0 failed, 1 ignored**.
- E2E on the official subscription: reviews now run and score real values (79 → approved @70 → feature tasks created; 44/53/56 on other runs); the auto-complete sweep now triggers the review instead of bypassing it (confirmed in logs); transport shows 0 structural-incompleteness / 0 exhaustion when claude returns clean end_turn responses.

## Remaining (environmental, not code)
An **intermittent** \`Invalid API key\` from the subscription can leave a coder terminal idling with no commit, which a (correct) review then rejects as "no changed content". This is a subscription-credential flake, not a code bug — an API key removes it entirely (the orchestrator then uses the reliable HTTP LLM client). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)