### PR TITLE
fix: integration-sensitive audit fixes (Tier-2, split from #30)

### DIFF
--- a/crates/executors/src/executors/claude/protocol.rs
+++ b/crates/executors/src/executors/claude/protocol.rs
@@ -55,19 +55,26 @@ impl ProtocolPeer {
         let mut interrupt_rx = interrupt_rx.fuse();
 
         loop {
-            buffer.clear();
             tokio::select! {
                 line_result = reader.read_line(&mut buffer) => {
                     match line_result {
                         Ok(0) => break, // EOF
                         Ok(_) => {
+                            // `read_line` is NOT cancellation-safe: if the
+                            // interrupt branch below wins mid-read, bytes
+                            // already appended to `buffer` would be lost. We
+                            // therefore only take/clear `buffer` here, after a
+                            // COMPLETE line was read, leaving any partially-read
+                            // bytes intact across a cancellation so the next
+                            // `read_line` continues appending the remainder.
+                            let line_owned = std::mem::take(&mut buffer);
                             // E33-07: `trim()` strips both leading and trailing
                             // whitespace (including the `\n` terminator). This
                             // is acceptable here because the Claude CLI emits
                             // one JSON object per line, and any leading/
                             // trailing whitespace is never semantically
                             // significant inside the line framing.
-                            let line = buffer.trim();
+                            let line = line_owned.trim();
                             if line.is_empty() {
                                 continue;
                             }

--- a/crates/executors/src/executors/claude/protocol.rs
+++ b/crates/executors/src/executors/claude/protocol.rs
@@ -50,24 +50,43 @@ impl ProtocolPeer {
         interrupt_rx: oneshot::Receiver<()>,
     ) -> Result<(), ExecutorError> {
         let mut reader = BufReader::new(stdout);
-        let mut buffer = String::new();
+        // Byte buffer for `read_until`: it accumulates partially-read bytes
+        // IN PLACE across cancelled reads, which is what makes the select!
+        // loop below cancellation-safe (see the read branch comment).
+        let mut buffer: Vec<u8> = Vec::new();
         // Fuse the receiver so it returns Pending forever after completing
         let mut interrupt_rx = interrupt_rx.fuse();
 
         loop {
             tokio::select! {
-                line_result = reader.read_line(&mut buffer) => {
-                    match line_result {
-                        Ok(0) => break, // EOF
+                read_result = reader.read_until(b'\n', &mut buffer) => {
+                    match read_result {
+                        // EOF: this call appended no bytes. An unterminated
+                        // tail left in `buffer` (child exited mid-line after a
+                        // cancelled read) is dropped, matching the previous
+                        // `read_line` behavior at EOF.
+                        Ok(0) => break,
                         Ok(_) => {
-                            // `read_line` is NOT cancellation-safe: if the
-                            // interrupt branch below wins mid-read, bytes
-                            // already appended to `buffer` would be lost. We
-                            // therefore only take/clear `buffer` here, after a
-                            // COMPLETE line was read, leaving any partially-read
-                            // bytes intact across a cancellation so the next
-                            // `read_line` continues appending the remainder.
-                            let line_owned = std::mem::take(&mut buffer);
+                            // Cancellation safety (why `read_until`, not
+                            // `read_line`): tokio's `read_line` moves the
+                            // caller's String into its future, so when the
+                            // interrupt branch below wins mid-read the partial
+                            // bytes are dropped with the future and the line
+                            // is torn. `read_until` borrows `buffer` and
+                            // appends in place, completing only at the
+                            // delimiter or EOF — a cancelled call leaves the
+                            // partial bytes in `buffer` and the next call
+                            // appends the remainder, so lines are never torn.
+                            let line_owned =
+                                match String::from_utf8(std::mem::take(&mut buffer)) {
+                                    Ok(s) => s,
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Error reading stdout: CLI emitted invalid UTF-8: {e}"
+                                        );
+                                        break;
+                                    }
+                                };
                             // E33-07: `trim()` strips both leading and trailing
                             // whitespace (including the `\n` terminator). This
                             // is acceptable here because the Claude CLI emits

--- a/crates/executors/src/executors/cursor.rs
+++ b/crates/executors/src/executors/cursor.rs
@@ -996,6 +996,7 @@ pub struct CursorShellOutcome {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct CursorShellWrappedResult {
     #[serde(default)]
     pub success: Option<CursorShellOutcome>,
@@ -1041,6 +1042,7 @@ pub struct CursorMcpOutcome {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct CursorMcpWrappedResult {
     #[serde(default)]
     pub success: Option<CursorMcpOutcome>,

--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -1735,15 +1735,19 @@ impl LocalContainerService {
 
             let mut has_global_auth = false;
 
-            // Copy config.json and settings.json from global if they exist
+            // Copy config.json, settings.json, and the native OAuth credential file
+            // (.credentials.json) from global if they exist. The native-auth marker
+            // is .credentials.json — mirroring build_launch_config /
+            // setup_interactive_auth and has_native_creds above — NOT config.json,
+            // which is only onboarding state and may not carry any key.
             if let Some(ref global_home) = global_claude_home {
-                for filename in &["config.json", "settings.json"] {
+                for filename in &["config.json", "settings.json", ".credentials.json"] {
                     let src = global_home.join(filename);
                     if src.exists() {
                         if let Err(e) = std::fs::copy(&src, claude_home.join(filename)) {
                             tracing::warn!(error = %e, file = filename, "Failed to copy Claude config to workspace");
                         }
-                        if *filename == "config.json" {
+                        if *filename == ".credentials.json" {
                             has_global_auth = true;
                         }
                     }

--- a/crates/services/src/services/git.rs
+++ b/crates/services/src/services/git.rs
@@ -1919,24 +1919,59 @@ impl GitService {
         // Set up callbacks for authentication if token is provided
         let mut callbacks = RemoteCallbacks::new();
         if let Some(token) = token {
-            callbacks.credentials(|_url, username_from_url, _allowed_types| {
-                Cred::userpass_plaintext(username_from_url.unwrap_or("git"), token)
+            let attempts = std::cell::Cell::new(0u32);
+            callbacks.credentials(move |_url, username_from_url, allowed_types| {
+                // Two-phase auth: satisfy the USERNAME request first.
+                if allowed_types.contains(git2::CredentialType::USERNAME) {
+                    return Cred::username(username_from_url.unwrap_or("git"));
+                }
+                if allowed_types.contains(git2::CredentialType::USER_PASS_PLAINTEXT) {
+                    let n = attempts.get();
+                    if n >= 1 {
+                        return Err(git2::Error::from_str(
+                            "authentication failed: token credentials exhausted",
+                        ));
+                    }
+                    attempts.set(n + 1);
+                    return Cred::userpass_plaintext(username_from_url.unwrap_or("git"), token);
+                }
+                Err(git2::Error::from_str(
+                    "no supported authentication method offered by server",
+                ))
             });
         } else {
             // Fallback to SSH agent and key file authentication
-            callbacks.credentials(|_url, username_from_url, _| {
-                // Try SSH agent first
-                if let Some(username) = username_from_url
-                    && let Ok(cred) = Cred::ssh_key_from_agent(username)
-                {
-                    return Ok(cred);
+            let attempts = std::cell::Cell::new(0u32);
+            callbacks.credentials(move |_url, username_from_url, allowed_types| {
+                let username = username_from_url.unwrap_or("git");
+                // Two-phase SSH auth: satisfy the USERNAME request first.
+                if allowed_types.contains(git2::CredentialType::USERNAME) {
+                    return Cred::username(username);
                 }
-
-                // Fallback to key file (~/.ssh/id_rsa)
-                let home = dirs::home_dir()
-                    .ok_or_else(|| git2::Error::from_str("Could not find home directory"))?;
-                let key_path = home.join(".ssh").join("id_rsa");
-                Cred::ssh_key(username_from_url.unwrap_or("git"), None, &key_path, None)
+                if !allowed_types.contains(git2::CredentialType::SSH_KEY) {
+                    return Err(git2::Error::from_str(
+                        "no supported authentication method offered by server",
+                    ));
+                }
+                let n = attempts.get();
+                attempts.set(n + 1);
+                match n {
+                    // Try SSH agent first
+                    0 => Cred::ssh_key_from_agent(username),
+                    // Fallback to key file (~/.ssh/id_rsa)
+                    1 => {
+                        let home = dirs::home_dir().ok_or_else(|| {
+                            git2::Error::from_str("Could not find home directory")
+                        })?;
+                        let key_path = home.join(".ssh").join("id_rsa");
+                        Cred::ssh_key(username, None, &key_path, None)
+                    }
+                    // Exhausted: return Err so libgit2 stops retrying and a
+                    // clean auth error propagates instead of looping.
+                    _ => Err(git2::Error::from_str(
+                        "authentication failed: SSH credentials exhausted",
+                    )),
+                }
             });
         }
 


### PR DESCRIPTION
## Summary

Four self-contained fixes from the multi-agent audit that were split out of #30 because they touch **external-integration paths CI cannot exercise headless** (real `git` clone, live Claude/Cursor CLIs, workspace auth files). Isolating them lets the ~55 zero/low-risk fixes in #30 merge immediately while these get their own validation.

Each change is confined to a single file and does not depend on the other audit fixes.

## Changes

- **`crates/services/src/services/git.rs`** — honor the git2 credential contract in `clone_repository`: satisfy the `USERNAME` phase, respect `allowed_types`, and return `Err` after credentials are exhausted. Fixes SSH handshake failures ("username does not match previous request") and HTTPS auth-retry loops.
- **`crates/local-deployment/src/container.rs`** — copy `.credentials.json` into the isolated `CLAUDE_HOME` and key `has_global_auth` on it (the real native-OAuth marker) rather than `config.json` (onboarding state only). Subscription/OAuth users were otherwise getting an unauthenticated CLI in workspace mode.
- **`crates/executors/src/executors/cursor.rs`** — add `#[serde(deny_unknown_fields)]` to the wrapped shell/MCP result structs so untagged deserialization stops matching flat outcomes first, which made failed shell/MCP calls report as success with dropped output.
- **`crates/executors/src/executors/claude/protocol.rs`** — make the `read_line` loop cancellation-safe via `std::mem::take` so an interrupt mid-read cannot discard partially-read line bytes (which corrupted the next JSON message).

## Why separate

CI validates compile / clippy `-D warnings` / `nextest --lib` / frontend — not live git clone, live CLI parsing, or workspace auth. These four are corrections rather than rewrites of working behavior, but their runtime paths aren't covered by automated tests, so they warrant targeted validation.

## Suggested validation before merge

1. Real `git clone` over **HTTPS (token)** and **SSH**.
2. Workspace-mode Claude run for both **native-OAuth (subscription)** and **API-key** auth.
3. A **Cursor** shell/MCP tool call (verify a failing command reports failure).
4. A **Claude interactive** run with an **interrupt** mid-stream.

## Risk

Analysis in #30 assessed all four as net improvements with narrow residual risk (the only notable one: `cursor` `deny_unknown_fields` is brittle if Cursor later *adds* fields to its wrapped result). Confined to the git-clone / workspace-auth / cursor / claude paths respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017rrjizYLzc2rZ3c5u9bLAb)_