### PR TITLE
feat(planning): architecture knowledge base & design style system

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -102,6 +102,78 @@ For the full LGPL-3.0 text, see: https://www.gnu.org/licenses/lgpl-3.0.html
 
 ---
 
+## 5. shadcn/ui (MIT License)
+
+Copyright (c) 2023 shadcn
+
+The reusable UI components under `frontend/src/components/ui/` are based on
+shadcn/ui (https://github.com/shadcn-ui/ui), which distributes components by
+copying source code into the consuming project (configured via
+`frontend/components.json`). These components were inherited from the Vibe
+Kanban upstream and extended in SoloDawn. They are licensed under the MIT
+License; the full MIT license text reproduced in Section 3 applies with the
+copyright notice above.
+
+---
+
+## 6. Design Style Presets (Adapted Content)
+
+The built-in design style presets under
+`crates/services/assets/design_styles/` are condensed adaptations of
+open-source design skills. Each file carries an attribution header marking
+the source, license, and the changes made (condensed and adapted for
+automated prompt injection). The upstream sources are:
+
+| Preset file | Upstream project | License |
+|---|---|---|
+| `anthropic-frontend-design.md` | `frontend-design` skill in anthropics/skills (https://github.com/anthropics/skills) | Apache-2.0 |
+| `taste-minimalist-editorial.md` | `minimalist-ui` skill in Leonxlnx/taste-skill (https://github.com/Leonxlnx/taste-skill) | MIT |
+| `taste-industrial-brutalist.md` | `industrial-brutalist-ui` skill in Leonxlnx/taste-skill (https://github.com/Leonxlnx/taste-skill) | MIT |
+| `taste-soft-premium.md` | `soft-skill` skill in Leonxlnx/taste-skill (https://github.com/Leonxlnx/taste-skill) | MIT |
+| `impeccable-design-language.md` | pbakaus/impeccable (https://github.com/pbakaus/impeccable) | Apache-2.0 |
+| `emil-design-engineering.md` | `emil-design-eng` skill in emilkowalski/skills (https://github.com/emilkowalski/skills) | MIT |
+
+Apache-2.0 sources (anthropics/skills, pbakaus/impeccable): used under the
+Apache License 2.0; modifications are marked in each file's attribution
+header as required by Section 4(b) of the license.
+
+MIT sources — the following upstream copyright notices are reproduced
+verbatim; the full MIT license text in Section 3 applies to each:
+
+- Copyright (c) 2026 Leonxlnx (Leonxlnx/taste-skill)
+- Copyright (c) 2026 Matt Pocock (as stated in the LICENSE of
+  emilkowalski/skills, the repository maintained by Emil Kowalski)
+
+---
+
+## 7. Architecture Methodology & Knowledge Sources
+
+**architecture-copilot (MIT License)**
+
+Copyright (c) 2026 JingWen Fan (study8677)
+
+The architecture-thinking checklist at
+`crates/services/assets/architecture/methodology.md` is a condensed
+adaptation of the architecture-copilot skill
+(https://github.com/study8677/architecture-copilot). Changes are marked in
+the file's attribution header. The full MIT license text in Section 3
+applies with the copyright notice above.
+
+**awesome-architecture (MIT License)**
+
+Copyright (c) 2026 JingWen Fan (study8677)
+
+SoloDawn's architecture knowledge base syncs reference-architecture
+templates at runtime from GitHub repositories configured as knowledge
+sources. The built-in default source is
+https://github.com/study8677/awesome-architecture (MIT). Synced content is
+stored in the user's local database and injected into planning prompts;
+it is not redistributed with SoloDawn releases. Content from knowledge
+sources added by users is governed by those sources' own licenses and is
+the responsibility of the user who adds them.
+
+---
+
 ## Summary
 
 | Component | License | Location |
@@ -110,6 +182,10 @@ For the full LGPL-3.0 text, see: https://www.gnu.org/licenses/lgpl-3.0.html
 | Vibe Kanban (upstream) | Apache-2.0 | Inherited throughout the codebase |
 | CC-Switch | MIT | `crates/cc-switch/` |
 | SonarQube Quality Gate Models | LGPL-3.0 | `crates/quality/src/gate/` |
+| shadcn/ui | MIT | `frontend/src/components/ui/` |
+| Design style presets (anthropics/skills, Leonxlnx/taste-skill, pbakaus/impeccable, emilkowalski/skills) | Apache-2.0 / MIT | `crates/services/assets/design_styles/` |
+| Architecture methodology (study8677/architecture-copilot) | MIT | `crates/services/assets/architecture/` |
+| Architecture knowledge sync (study8677/awesome-architecture, default source) | MIT | Runtime-synced into the local database |
 
 For the full Apache License 2.0 text, see: http://www.apache.org/licenses/LICENSE-2.0
 For the full MIT License text, see: https://opensource.org/licenses/MIT

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Step-by-step instructions for both modes are at the bottom of this file: [Usage 
 - ✅ Planning Draft lifecycle: gathering → spec_ready → confirmed → materialized
 - ✅ **Continuation rounds** (landed post-1.0): a delivered conversation continues in place — round N+1 plans only the delta, prior rounds fold into the same thread, one active round per project
 - ✅ **Requirement ledger (评分点)**: acceptance criteria become project-scoped points (`RP-001`, …) settled at scoring time — delivered points store a compressed context capsule, regressions are flagged per point
+- ✅ **Architecture-aware planning** (landed post-1.0): an architecture-thinking checklist plus reference-architecture digests, keyword-matched from a locally synced knowledge base (built-in source: awesome-architecture), are injected into the orchestrator when a round materializes; sources are user-extensible GitHub repos with automatic background refresh
+- ✅ **Design styles** (landed post-1.0): pick a visual direction per round in the workspace, or set a global default in Settings — 6 built-in presets adapted from high-rated open-source design skills, plus full custom style create / edit / delete; the chosen style is carried into every UI-related terminal instruction
 - ✅ Cross-terminal context handoff (each terminal's work passed to the next)
 - ✅ Automatic branch merging + a designated conflict-resolution terminal; optional "run tests before merge" and "pause on conflict"
 
@@ -410,6 +412,8 @@ The flow in one sentence: configure a model → bind a Git repository → (optio
 - **Programmer**: throw in a precise, specific task goal. The system uses your input directly as the technical spec, asks nothing, and only generates the acceptance scoring rubric in the background.
 - **Non-technical user**: skip the jargon entirely; describe the need in plain language from a user's perspective — "I want a local memo app; I'd like to view it in my browser, or have it be a desktop app that stays pinned on top…" The system asks plain-language follow-ups to close the gaps (you mention 3 features, it may ask "want to add these other two?"), and once the final requirement is confirmed it generates a technical spec + acceptance scoring rubric.
 
+Building something with a UI? Pick a **design style** from the toolbar next to the model selector — or leave it on the system default from Settings → Design Styles (see [Architecture Knowledge & Design Styles](#architecture-knowledge--design-styles)).
+
 Want your own acceptance criteria? Upload an audit document **before** confirming (Builtin / Merged / Custom modes — see [Acceptance Review & Scoring Rubric](#acceptance-review--scoring-rubric)); after confirmation the rubric panel becomes read-only.
 
 **Step 4: Click Confirm in the top-right.** Confirmation is two-step: first confirm the technical spec (the scoring rubric is generated and locked at that instant), then confirm the quality gate configuration. The generated rubric immediately appears as a card in the conversation — every acceptance criterion tagged with its requirement-point code (`RP-001`, …) — and the requirement ledger opens as a side panel next to the audit-doc panel. **Remember to click Confirm when the conversation is done — nothing executes otherwise.** This is a hard block in the code: only after both confirmations does the workflow materialize and start automatically.
@@ -433,6 +437,36 @@ For users who want full control over the workflow graph. The creation wizard has
 > **Power move: UltraCode.** A manual workflow launches your native terminal, so beyond your skills / MCP servers / plugins, the CLI's official built-in commands are inherited too — including UltraCode mode. Enable it by configuring a dedicated prompt for a task (the task description is typed into that task's terminal verbatim): UltraCode generates standardized workflow scripts that hardcode clear capability boundaries for each Agent, and invoking that script afterwards reuses the entire workflow.
 
 Manual workflow video demo (recorded February 2026 when the project was still called GitCortex; it covers only the manual workflow and the UI has since changed): [GitCortex minimal MVP demo — bilibili](https://www.bilibili.com/video/BV1yxfMBCEFh/)
+
+## Architecture Knowledge & Design Styles
+
+Two additions that shape *how* the orchestrated workspace plans and builds.
+
+### Architecture-aware planning
+
+When a round materializes, the planner's goal is enriched with an **Architecture Guidance** section built from two parts:
+
+- **A self-answered architecture checklist** (adapted from [study8677/architecture-copilot](https://github.com/study8677/architecture-copilot), MIT): system boundaries → data model → sync/async flows → capacity honesty. The orchestrator answers it while decomposing, so the plan states its architecture assumptions instead of hiding them.
+- **Matched reference digests**: SoloDawn keeps a local knowledge base synced from GitHub — the built-in source is [study8677/awesome-architecture](https://github.com/study8677/awesome-architecture) (MIT), a set of uniformly structured reference architectures. At confirm time, the requirement text is keyword-matched against the entries and the top digests (key decisions / tradeoffs / scaling / anti-patterns) are attached.
+
+**Settings → Architecture Knowledge** lets you toggle the guidance, add your own GitHub repositories as knowledge sources (markdown files under chosen path prefixes), trigger a manual sync, and see per-source sync status. Background sync checks roughly every 6 hours and refreshes any source more than 24 hours stale; only changed files are fetched (blob-SHA diff). Setting `SOLODAWN_GITHUB_TOKEN` (or `GITHUB_TOKEN`) raises the GitHub API rate limit for private or heavily synced sources.
+
+### Design styles
+
+Pick a **design style** in the workspace conversation toolbar (per round), or set a global default in **Settings → Design Styles**. When a round materializes with a style, its directives are appended to the goal as a **Design Direction** section, and the orchestrator contract requires carrying it into **every UI-related terminal instruction** — including the foundation task that lays down base styles, so the visual language stays consistent across parallel terminals.
+
+Six presets ship built-in, condensed from high-rated open-source design skills (each file carries source and license attribution — see `LICENSE`):
+
+| Preset | Adapted from | License |
+|---|---|---|
+| Anthropic Frontend Design | anthropics/skills — frontend-design | Apache-2.0 |
+| Minimalist Editorial | Leonxlnx/taste-skill — minimalist-ui | MIT |
+| Industrial Brutalist | Leonxlnx/taste-skill — industrial-brutalist-ui | MIT |
+| Soft Premium | Leonxlnx/taste-skill — soft-skill | MIT |
+| Impeccable Design Language | pbakaus/impeccable | Apache-2.0 |
+| Emil Design Engineering | emilkowalski/skills — emil-design-eng | MIT |
+
+Built-in presets are read-only — duplicate one to make it yours; custom styles support full create / edit / delete, and disabled styles are never injected.
 
 ## Quality System in Depth
 
@@ -679,7 +713,9 @@ cd frontend && pnpm test:run && pnpm run lint && pnpm run check && cd ..
 - Vibe Kanban derived parts: Apache-2.0
 - CC-Switch derived parts: MIT
 - Quality Gate models (ported from SonarQube): LGPL-3.0
-- See `LICENSE` for full details.
+- shadcn/ui components: MIT
+- Design style presets & architecture methodology (adapted from open-source skills): MIT / Apache-2.0
+- See `LICENSE` for full details and per-source attribution.
 
 ## Blogroll
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,6 +73,8 @@ SoloDawn 的最终设计目标是**通过社交平台的简单对话，完成复
 - ✅ Planning Draft 生命周期：gathering → spec_ready → confirmed → materialized
 - ✅ **多轮继续开发**（1.0 后落地）：已交付的对话可原地开下一轮——新一轮只规划增量，旧轮次折叠进同一会话，每个项目同时只跑一轮
 - ✅ **评分点账本**：验收标准登记为项目级评分点（`RP-001`…），评分即结算——已交付点写入压缩上下文纸条，回退逐点标记
+- ✅ **架构感知规划**（1.0 后落地）：一份架构思维清单 + 从本地同步知识库按关键词匹配出的参考架构摘要（内置源：awesome-architecture），在轮次物化时注入编排器；知识源是用户可扩展的 GitHub 仓库，后台自动刷新
+- ✅ **设计风格**（1.0 后落地）：在工作区按轮选择视觉方向，或在系统设置里设全局默认——内置 6 套改编自高分开源设计 skill 的预设，另支持自定义风格的完整增删改；所选风格会带入每一条 UI 相关的终端指令
 - ✅ 跨终端上下文传递（前序终端的成果传给下一个）
 - ✅ 自动分支合并 + 指定冲突解决终端；可选"合并前跑测试""冲突时暂停"
 
@@ -408,6 +410,8 @@ docker-compose -f docker-compose.split.yml up -d
 - **程序员**：直接扔一个非常准确的任务目标。系统把你的输入直接当技术规范用，不追问，只在后台生成验收评分规范。
 - **非技术人员**：别用任何技术术语，用大白话从用户角度说需求——"我想做一个本地备忘录，我希望在浏览器里看它；或者它是一个软件，显示在桌面上、能置顶……"系统会用大白话追问补全模糊点（比如你说了 3 个功能，它可能追问"还有两个要不要加？"），最终需求确认后自动生成技术规范 + 验收评分规范。
 
+要做带界面的东西？在模型选择器旁边的工具栏里挑一个**设计风格**——不挑就走系统设置 → 设计风格里的全局默认（见[架构知识与设计风格](#架构知识与设计风格)）。
+
 想用自己的验收标准？在确认**之前**上传审计文档（Builtin / Merged / Custom 三种模式，见[验收评审与评分规范](#验收评审与评分规范)）；确认后评分规范面板变为只读。
 
 **第 4 步：点右上角的确认。** 确认分两步：先确认技术规范（此刻生成并锁定评分规范），再确认质量门配置。生成的评分规范会立刻以卡片形式出现在对话里——每条验收标准都带着自己的评分点编号（`RP-001`…）——需求清单也会作为侧边栏出现在审计文档面板旁边。**对话完成后记得点确认，不点不会执行**——这是代码层的硬性拦截：两步确认都完成后，工作流才会物化并自动启动。
@@ -431,6 +435,36 @@ docker-compose -f docker-compose.split.yml up -d
 > **进阶玩法：UltraCode。** 手动工作流启动的是你的原生终端，因此除了你的 skill / MCP / 插件，CLI 的官方内置命令也全部继承——包括 UltraCode 模式。为任务配置专用提示词即可启用（任务描述会原样输入到该任务的终端）：UltraCode 会生成标准化的工作流脚本，为每个 Agent 硬编码清晰的能力边界，之后直接调用该脚本即可复用整套工作流。
 
 手动工作流视频演示（2026 年 2 月录制，当时项目还叫 GitCortex，仅演示了手动工作流，界面与现版本已有差异）：[GitCortex 最小 MVP 演示视频 - bilibili](https://www.bilibili.com/video/BV1yxfMBCEFh/)
+
+## 架构知识与设计风格
+
+两项影响编排工作区"怎么规划、怎么做"的新增能力。
+
+### 架构感知规划
+
+轮次物化时，规划目标会追加一段**架构指引（Architecture Guidance）**，由两部分组成：
+
+- **自答式架构思维清单**（改编自 [study8677/architecture-copilot](https://github.com/study8677/architecture-copilot)，MIT）：系统边界 → 数据模型 → 同步/异步流 → 容量诚实。编排器在拆解任务时逐项作答，让方案把架构假设摆到明面上，而不是藏在实现里。
+- **匹配到的参考架构摘要**：SoloDawn 维护一个从 GitHub 同步的本地知识库——内置源是 [study8677/awesome-architecture](https://github.com/study8677/awesome-architecture)（MIT），一组结构统一的参考架构模板。确认时用需求文本对条目做关键词匹配，把得分最高的摘要（关键决策 / 权衡 / 规模化 / 反模式）附进去。
+
+**系统设置 → 架构知识**里可以开关指引、把你自己的 GitHub 仓库加为知识源（按路径前缀同步其中的 markdown 文件）、手动触发同步、查看每个源的同步状态。后台同步约每 6 小时检查一次，超过 24 小时未同步的源会自动刷新；只拉取有变化的文件（blob-SHA 差量）。设置 `SOLODAWN_GITHUB_TOKEN`（或 `GITHUB_TOKEN`）可提高 GitHub API 速率上限。
+
+### 设计风格
+
+在工作区对话工具栏里按轮选择**设计风格**，或在**系统设置 → 设计风格**里设全局默认。带风格的轮次物化时，风格指令会以**设计方向（Design Direction）**段落追加进目标，且编排器契约要求把它带进**每一条 UI 相关的终端指令**——包括铺设基础样式的地基任务，保证并行终端之间视觉语言一致。
+
+内置 6 套预设，浓缩自高分开源设计 skill（每个文件都带来源与许可证署名，详见 `LICENSE`）：
+
+| 预设 | 改编自 | 许可证 |
+|---|---|---|
+| Anthropic Frontend Design | anthropics/skills — frontend-design | Apache-2.0 |
+| Minimalist Editorial | Leonxlnx/taste-skill — minimalist-ui | MIT |
+| Industrial Brutalist | Leonxlnx/taste-skill — industrial-brutalist-ui | MIT |
+| Soft Premium | Leonxlnx/taste-skill — soft-skill | MIT |
+| Impeccable Design Language | pbakaus/impeccable | Apache-2.0 |
+| Emil Design Engineering | emilkowalski/skills — emil-design-eng | MIT |
+
+内置预设只读——复制一份即可改成自己的；自定义风格支持完整的新建 / 编辑 / 删除，停用的风格不会注入。
 
 ## 质量体系详解
 
@@ -672,7 +706,9 @@ cd frontend && pnpm test:run && pnpm run lint && pnpm run check && cd ..
 - Vibe Kanban 衍生部分：Apache-2.0
 - CC-Switch 衍生部分：MIT
 - 质量门模型（移植自 SonarQube）：LGPL-3.0
-- 详见 `LICENSE`
+- shadcn/ui 组件：MIT
+- 设计风格预设与架构方法论（改编自开源 skill）：MIT / Apache-2.0
+- 完整条款与逐源署名详见 `LICENSE`
 
 ## 友链
 

--- a/crates/db/migrations/20260704040000_architecture_knowledge.sql
+++ b/crates/db/migrations/20260704040000_architecture_knowledge.sql
@@ -1,0 +1,48 @@
+-- Architecture knowledge base: GitHub-synced architecture guidance that the
+-- planner injects into workflow goals (methodology checklist + per-system
+-- template digests). Sources are configurable repos; the builtin source
+-- (study8677/awesome-architecture, MIT) is seeded at startup, not here, so
+-- the seed content lives next to the code that maintains it.
+CREATE TABLE IF NOT EXISTS architecture_source (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    -- GitHub coordinates: https://github.com/{owner}/{repo}, tree {branch}.
+    owner TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    branch TEXT NOT NULL DEFAULT 'main',
+    -- JSON array of path prefixes to sync (e.g. ["templates/"]).
+    include_paths TEXT NOT NULL DEFAULT '["templates/"]',
+    enabled INTEGER NOT NULL DEFAULT 1,
+    -- Builtin sources cannot be deleted, only disabled.
+    builtin INTEGER NOT NULL DEFAULT 0,
+    -- Git tree sha of the last successful sync; unchanged sha = skip walk.
+    last_tree_sha TEXT,
+    last_synced_at DATETIME,
+    -- 'ok' or 'error: <message>' from the most recent sync attempt.
+    last_sync_status TEXT,
+    created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(owner, repo, branch)
+);
+
+-- One row per synced markdown document. digest carries the prompt-injectable
+-- extract (key decisions / bottlenecks / anti-patterns sections); content
+-- keeps the full document so digests can be re-derived without refetching.
+CREATE TABLE IF NOT EXISTS architecture_entry (
+    id TEXT PRIMARY KEY,
+    source_id TEXT NOT NULL REFERENCES architecture_source(id) ON DELETE CASCADE,
+    path TEXT NOT NULL,
+    -- template | tutorial | case | other (derived from the path prefix).
+    category TEXT NOT NULL DEFAULT 'other',
+    slug TEXT NOT NULL,
+    title TEXT NOT NULL,
+    -- JSON array of matching keywords extracted at sync time.
+    keywords TEXT NOT NULL DEFAULT '[]',
+    digest TEXT NOT NULL,
+    content TEXT NOT NULL,
+    blob_sha TEXT NOT NULL,
+    synced_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(source_id, path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_architecture_entry_source ON architecture_entry(source_id, category);

--- a/crates/db/migrations/20260704040001_design_styles.sql
+++ b/crates/db/migrations/20260704040001_design_styles.sql
@@ -1,0 +1,28 @@
+-- Design style templates: reusable visual-direction prompts injected into
+-- planner goals so UI work follows a chosen aesthetic. Builtin presets
+-- (adapted from high-star open-source design skills, see LICENSE) are seeded
+-- at startup from crates/services/assets/design_styles/; users add their own
+-- via the design-styles API.
+CREATE TABLE IF NOT EXISTS design_style (
+    id TEXT PRIMARY KEY,
+    slug TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    -- The design directive prompt injected for UI-related work.
+    content TEXT NOT NULL,
+    -- Attribution for builtin presets (NULL for user-created styles).
+    source_name TEXT,
+    source_url TEXT,
+    license TEXT,
+    -- Builtin styles cannot be deleted or content-edited, only disabled;
+    -- users duplicate them into custom styles to modify.
+    builtin INTEGER NOT NULL DEFAULT 0,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    updated_at DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Per-round style selection: which design style this draft's workflow should
+-- follow. NULL falls back to the system default (system_settings key
+-- 'default_design_style'), then to none. Additive and nullable.
+ALTER TABLE planning_draft ADD COLUMN design_style_slug TEXT;

--- a/crates/db/src/models/architecture_entry.rs
+++ b/crates/db/src/models/architecture_entry.rs
@@ -1,0 +1,198 @@
+//! Synced architecture knowledge documents. One row per markdown file pulled
+//! from an [`ArchitectureSource`](super::architecture_source::ArchitectureSource);
+//! `digest` holds the prompt-injectable extract, `content` the full document.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, SqlitePool};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitectureEntry {
+    pub id: String,
+    pub source_id: String,
+    pub path: String,
+    pub category: String,
+    pub slug: String,
+    pub title: String,
+    /// JSON array of matching keywords extracted at sync time.
+    pub keywords: String,
+    pub digest: String,
+    pub content: String,
+    pub blob_sha: String,
+    pub synced_at: DateTime<Utc>,
+}
+
+/// Listing projection without the heavyweight `content`/`digest` columns.
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitectureEntrySummary {
+    pub id: String,
+    pub source_id: String,
+    pub path: String,
+    pub category: String,
+    pub slug: String,
+    pub title: String,
+    pub synced_at: DateTime<Utc>,
+}
+
+impl ArchitectureEntry {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        source_id: &str,
+        path: &str,
+        category: &str,
+        slug: &str,
+        title: &str,
+        keywords: &[String],
+        digest: &str,
+        content: &str,
+        blob_sha: &str,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            source_id: source_id.to_string(),
+            path: path.to_string(),
+            category: category.to_string(),
+            slug: slug.to_string(),
+            title: title.to_string(),
+            keywords: serde_json::to_string(keywords).unwrap_or_else(|_| "[]".to_string()),
+            digest: digest.to_string(),
+            content: content.to_string(),
+            blob_sha: blob_sha.to_string(),
+            synced_at: Utc::now(),
+        }
+    }
+
+    /// Parse the JSON `keywords` column; invalid JSON yields an empty list.
+    pub fn keyword_list(&self) -> Vec<String> {
+        serde_json::from_str(&self.keywords).unwrap_or_default()
+    }
+
+    /// Insert or refresh the entry for `(source_id, path)`.
+    pub async fn upsert(pool: &SqlitePool, entry: &Self) -> sqlx::Result<()> {
+        sqlx::query(
+            r"
+            INSERT INTO architecture_entry (
+                id, source_id, path, category, slug, title,
+                keywords, digest, content, blob_sha, synced_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+            ON CONFLICT(source_id, path) DO UPDATE SET
+                category = excluded.category,
+                slug = excluded.slug,
+                title = excluded.title,
+                keywords = excluded.keywords,
+                digest = excluded.digest,
+                content = excluded.content,
+                blob_sha = excluded.blob_sha,
+                synced_at = excluded.synced_at
+            ",
+        )
+        .bind(&entry.id)
+        .bind(&entry.source_id)
+        .bind(&entry.path)
+        .bind(&entry.category)
+        .bind(&entry.slug)
+        .bind(&entry.title)
+        .bind(&entry.keywords)
+        .bind(&entry.digest)
+        .bind(&entry.content)
+        .bind(&entry.blob_sha)
+        .bind(entry.synced_at)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Existing `(path, blob_sha)` pairs for a source, used to diff trees.
+    pub async fn sha_index(pool: &SqlitePool, source_id: &str) -> sqlx::Result<Vec<(String, String)>> {
+        sqlx::query_as::<_, (String, String)>(
+            "SELECT path, blob_sha FROM architecture_entry WHERE source_id = ?1",
+        )
+        .bind(source_id)
+        .fetch_all(pool)
+        .await
+    }
+
+    /// Remove entries whose paths vanished from the upstream tree.
+    pub async fn delete_missing(
+        pool: &SqlitePool,
+        source_id: &str,
+        keep_paths: &[String],
+    ) -> sqlx::Result<u64> {
+        // SQLite has no array binds; serialize to JSON and use json_each.
+        let keep_json = serde_json::to_string(keep_paths).unwrap_or_else(|_| "[]".to_string());
+        let result = sqlx::query(
+            r"
+            DELETE FROM architecture_entry
+            WHERE source_id = ?1
+              AND path NOT IN (SELECT value FROM json_each(?2))
+            ",
+        )
+        .bind(source_id)
+        .bind(keep_json)
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
+    /// Lightweight listing (no content/digest payloads).
+    pub async fn list_summaries(
+        pool: &SqlitePool,
+        source_id: Option<&str>,
+    ) -> sqlx::Result<Vec<ArchitectureEntrySummary>> {
+        match source_id {
+            Some(sid) => {
+                sqlx::query_as::<_, ArchitectureEntrySummary>(
+                    r"
+                    SELECT id, source_id, path, category, slug, title, synced_at
+                    FROM architecture_entry WHERE source_id = ?1
+                    ORDER BY category, slug
+                    ",
+                )
+                .bind(sid)
+                .fetch_all(pool)
+                .await
+            }
+            None => {
+                sqlx::query_as::<_, ArchitectureEntrySummary>(
+                    r"
+                    SELECT id, source_id, path, category, slug, title, synced_at
+                    FROM architecture_entry
+                    ORDER BY category, slug
+                    ",
+                )
+                .fetch_all(pool)
+                .await
+            }
+        }
+    }
+
+    /// All entries from enabled sources, used for requirement matching.
+    /// Excludes `content` via a projection onto the full struct with an
+    /// empty content column to keep the scan cheap.
+    pub async fn find_matchable(pool: &SqlitePool) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as::<_, Self>(
+            r"
+            SELECT e.id, e.source_id, e.path, e.category, e.slug, e.title,
+                   e.keywords, e.digest, '' AS content, e.blob_sha, e.synced_at
+            FROM architecture_entry e
+            JOIN architecture_source s ON s.id = e.source_id
+            WHERE s.enabled = 1
+            ORDER BY e.category, e.slug
+            ",
+        )
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn count_by_source(pool: &SqlitePool, source_id: &str) -> sqlx::Result<i64> {
+        let row: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM architecture_entry WHERE source_id = ?1")
+                .bind(source_id)
+                .fetch_one(pool)
+                .await?;
+        Ok(row.0)
+    }
+}

--- a/crates/db/src/models/architecture_source.rs
+++ b/crates/db/src/models/architecture_source.rs
@@ -1,0 +1,180 @@
+//! Architecture knowledge sources: GitHub repos the sync service pulls
+//! architecture guidance from. The builtin source (awesome-architecture)
+//! is ensured at startup; users may add further repos.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, SqlitePool};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchitectureSource {
+    pub id: String,
+    pub name: String,
+    pub owner: String,
+    pub repo: String,
+    pub branch: String,
+    /// JSON array of path prefixes to sync (e.g. `["templates/"]`).
+    pub include_paths: String,
+    pub enabled: bool,
+    pub builtin: bool,
+    pub last_tree_sha: Option<String>,
+    pub last_synced_at: Option<DateTime<Utc>>,
+    pub last_sync_status: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl ArchitectureSource {
+    pub fn new(name: &str, owner: &str, repo: &str, branch: &str, include_paths: &[&str]) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4().to_string(),
+            name: name.to_string(),
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            branch: branch.to_string(),
+            include_paths: serde_json::to_string(include_paths)
+                .unwrap_or_else(|_| "[]".to_string()),
+            enabled: true,
+            builtin: false,
+            last_tree_sha: None,
+            last_synced_at: None,
+            last_sync_status: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Parse the JSON `include_paths` column; invalid JSON yields an empty list.
+    pub fn include_path_list(&self) -> Vec<String> {
+        serde_json::from_str(&self.include_paths).unwrap_or_default()
+    }
+
+    pub async fn insert(pool: &SqlitePool, source: &Self) -> sqlx::Result<()> {
+        sqlx::query(
+            r"
+            INSERT INTO architecture_source (
+                id, name, owner, repo, branch, include_paths,
+                enabled, builtin, last_tree_sha, last_synced_at, last_sync_status,
+                created_at, updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            ",
+        )
+        .bind(&source.id)
+        .bind(&source.name)
+        .bind(&source.owner)
+        .bind(&source.repo)
+        .bind(&source.branch)
+        .bind(&source.include_paths)
+        .bind(source.enabled)
+        .bind(source.builtin)
+        .bind(&source.last_tree_sha)
+        .bind(source.last_synced_at)
+        .bind(&source.last_sync_status)
+        .bind(source.created_at)
+        .bind(source.updated_at)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn find_all(pool: &SqlitePool) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as::<_, Self>("SELECT * FROM architecture_source ORDER BY created_at ASC")
+            .fetch_all(pool)
+            .await
+    }
+
+    pub async fn find_enabled(pool: &SqlitePool) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as::<_, Self>(
+            "SELECT * FROM architecture_source WHERE enabled = 1 ORDER BY created_at ASC",
+        )
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn find_by_id(pool: &SqlitePool, id: &str) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>("SELECT * FROM architecture_source WHERE id = ?1")
+            .bind(id)
+            .fetch_optional(pool)
+            .await
+    }
+
+    pub async fn find_by_coords(
+        pool: &SqlitePool,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+    ) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>(
+            "SELECT * FROM architecture_source WHERE owner = ?1 AND repo = ?2 AND branch = ?3",
+        )
+        .bind(owner)
+        .bind(repo)
+        .bind(branch)
+        .fetch_optional(pool)
+        .await
+    }
+
+    /// Update the user-editable fields.
+    pub async fn update_settings(
+        pool: &SqlitePool,
+        id: &str,
+        name: &str,
+        branch: &str,
+        include_paths: &str,
+        enabled: bool,
+    ) -> sqlx::Result<()> {
+        sqlx::query(
+            r"
+            UPDATE architecture_source
+            SET name = ?2, branch = ?3, include_paths = ?4, enabled = ?5,
+                updated_at = datetime('now')
+            WHERE id = ?1
+            ",
+        )
+        .bind(id)
+        .bind(name)
+        .bind(branch)
+        .bind(include_paths)
+        .bind(enabled)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Record the outcome of a sync attempt.
+    pub async fn record_sync(
+        pool: &SqlitePool,
+        id: &str,
+        tree_sha: Option<&str>,
+        status: &str,
+    ) -> sqlx::Result<()> {
+        sqlx::query(
+            r"
+            UPDATE architecture_source
+            SET last_tree_sha = COALESCE(?2, last_tree_sha),
+                last_synced_at = datetime('now'),
+                last_sync_status = ?3,
+                updated_at = datetime('now')
+            WHERE id = ?1
+            ",
+        )
+        .bind(id)
+        .bind(tree_sha)
+        .bind(status)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Delete a non-builtin source. Returns the number of rows removed.
+    pub async fn delete_custom(pool: &SqlitePool, id: &str) -> sqlx::Result<u64> {
+        let result = sqlx::query("DELETE FROM architecture_source WHERE id = ?1 AND builtin = 0")
+            .bind(id)
+            .execute(pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+}

--- a/crates/db/src/models/design_style.rs
+++ b/crates/db/src/models/design_style.rs
@@ -1,0 +1,196 @@
+//! Design style templates: named visual-direction prompts. Builtin presets
+//! are seeded at startup from `crates/services/assets/design_styles/` and are
+//! immutable apart from the `enabled` flag; user styles support full CRUD.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, SqlitePool};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DesignStyle {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+    pub description: String,
+    /// The design directive prompt injected for UI-related work.
+    pub content: String,
+    pub source_name: Option<String>,
+    pub source_url: Option<String>,
+    pub license: Option<String>,
+    pub builtin: bool,
+    pub enabled: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl DesignStyle {
+    pub fn new(slug: &str, name: &str, description: &str, content: &str) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4().to_string(),
+            slug: slug.to_string(),
+            name: name.to_string(),
+            description: description.to_string(),
+            content: content.to_string(),
+            source_name: None,
+            source_url: None,
+            license: None,
+            builtin: false,
+            enabled: true,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub async fn insert(pool: &SqlitePool, style: &Self) -> sqlx::Result<()> {
+        sqlx::query(
+            r"
+            INSERT INTO design_style (
+                id, slug, name, description, content,
+                source_name, source_url, license, builtin, enabled,
+                created_at, updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+            ",
+        )
+        .bind(&style.id)
+        .bind(&style.slug)
+        .bind(&style.name)
+        .bind(&style.description)
+        .bind(&style.content)
+        .bind(&style.source_name)
+        .bind(&style.source_url)
+        .bind(&style.license)
+        .bind(style.builtin)
+        .bind(style.enabled)
+        .bind(style.created_at)
+        .bind(style.updated_at)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Upsert a builtin preset by slug, refreshing content and attribution
+    /// while preserving the user's `enabled` choice on existing rows.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn upsert_builtin(
+        pool: &SqlitePool,
+        slug: &str,
+        name: &str,
+        description: &str,
+        content: &str,
+        source_name: &str,
+        source_url: &str,
+        license: &str,
+    ) -> sqlx::Result<()> {
+        sqlx::query(
+            r"
+            INSERT INTO design_style (
+                id, slug, name, description, content,
+                source_name, source_url, license, builtin, enabled,
+                created_at, updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, 1, datetime('now'), datetime('now'))
+            ON CONFLICT(slug) DO UPDATE SET
+                name = excluded.name,
+                description = excluded.description,
+                content = excluded.content,
+                source_name = excluded.source_name,
+                source_url = excluded.source_url,
+                license = excluded.license,
+                builtin = 1,
+                updated_at = datetime('now')
+            ",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(slug)
+        .bind(name)
+        .bind(description)
+        .bind(content)
+        .bind(source_name)
+        .bind(source_url)
+        .bind(license)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn find_all(pool: &SqlitePool) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as::<_, Self>(
+            "SELECT * FROM design_style ORDER BY builtin DESC, created_at ASC",
+        )
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn find_by_id(pool: &SqlitePool, id: &str) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>("SELECT * FROM design_style WHERE id = ?1")
+            .bind(id)
+            .fetch_optional(pool)
+            .await
+    }
+
+    pub async fn find_by_slug(pool: &SqlitePool, slug: &str) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>("SELECT * FROM design_style WHERE slug = ?1")
+            .bind(slug)
+            .fetch_optional(pool)
+            .await
+    }
+
+    /// Resolve a slug to an enabled style, used at prompt-injection time.
+    pub async fn find_enabled_by_slug(pool: &SqlitePool, slug: &str) -> sqlx::Result<Option<Self>> {
+        sqlx::query_as::<_, Self>("SELECT * FROM design_style WHERE slug = ?1 AND enabled = 1")
+            .bind(slug)
+            .fetch_optional(pool)
+            .await
+    }
+
+    /// Update a user style. Builtin rows only accept the `enabled` flag; the
+    /// caller enforces that split — this method writes whatever it is given
+    /// for non-builtin rows.
+    pub async fn update_custom(
+        pool: &SqlitePool,
+        id: &str,
+        name: &str,
+        description: &str,
+        content: &str,
+        enabled: bool,
+    ) -> sqlx::Result<u64> {
+        let result = sqlx::query(
+            r"
+            UPDATE design_style
+            SET name = ?2, description = ?3, content = ?4, enabled = ?5,
+                updated_at = datetime('now')
+            WHERE id = ?1 AND builtin = 0
+            ",
+        )
+        .bind(id)
+        .bind(name)
+        .bind(description)
+        .bind(content)
+        .bind(enabled)
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
+    pub async fn set_enabled(pool: &SqlitePool, id: &str, enabled: bool) -> sqlx::Result<u64> {
+        let result = sqlx::query(
+            "UPDATE design_style SET enabled = ?2, updated_at = datetime('now') WHERE id = ?1",
+        )
+        .bind(id)
+        .bind(enabled)
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
+    /// Delete a non-builtin style. Returns the number of rows removed.
+    pub async fn delete_custom(pool: &SqlitePool, id: &str) -> sqlx::Result<u64> {
+        let result = sqlx::query("DELETE FROM design_style WHERE id = ?1 AND builtin = 0")
+            .bind(id)
+            .execute(pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+}

--- a/crates/db/src/models/mod.rs
+++ b/crates/db/src/models/mod.rs
@@ -15,8 +15,11 @@ pub mod workspace;
 pub mod workspace_repo;
 
 // SoloDawn Workflow models
+pub mod architecture_entry;
+pub mod architecture_source;
 pub mod cli_install_history;
 pub mod cli_type;
+pub mod design_style;
 pub mod concierge;
 pub mod custom_rule;
 pub mod custom_rule_audit;

--- a/crates/db/src/models/planning_draft.rs
+++ b/crates/db/src/models/planning_draft.rs
@@ -44,6 +44,9 @@ pub struct PlanningDraft {
     pub audit_mode: String,
     /// Path to user-uploaded audit document on disk.
     pub audit_doc_path: Option<String>,
+    /// Selected design style slug; NULL falls back to the system default
+    /// (`system_settings` key `default_design_style`), then to none.
+    pub design_style_slug: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -107,6 +110,7 @@ impl PlanningDraft {
             audit_plan: None,
             audit_mode: "builtin".to_string(),
             audit_doc_path: None,
+            design_style_slug: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
@@ -122,9 +126,9 @@ impl PlanningDraft {
                 confirmed_at, gates_confirmed_at, materialized_workflow_id, parent_draft_id,
                 feishu_sync, feishu_chat_id,
                 sync_tools, sync_terminal, sync_progress, notify_on_completion,
-                audit_plan, audit_mode, audit_doc_path,
+                audit_plan, audit_mode, audit_doc_path, design_style_slug,
                 created_at, updated_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26)
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27)
             ",
         )
         .bind(&draft.id)
@@ -151,6 +155,7 @@ impl PlanningDraft {
         .bind(&draft.audit_plan)
         .bind(&draft.audit_mode)
         .bind(&draft.audit_doc_path)
+        .bind(&draft.design_style_slug)
         .bind(draft.created_at)
         .bind(draft.updated_at)
         .execute(pool)
@@ -235,6 +240,27 @@ impl PlanningDraft {
         .bind(requirement_summary)
         .bind(technical_spec)
         .bind(workflow_seed)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Set or clear the draft's design style selection.
+    pub async fn update_design_style(
+        pool: &SqlitePool,
+        id: &str,
+        design_style_slug: Option<&str>,
+    ) -> sqlx::Result<()> {
+        sqlx::query(
+            r"
+            UPDATE planning_draft SET
+                design_style_slug = ?2,
+                updated_at = datetime('now')
+            WHERE id = ?1
+            ",
+        )
+        .bind(id)
+        .bind(design_style_slug)
         .execute(pool)
         .await?;
         Ok(())

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -310,6 +310,24 @@ async fn run_server() -> Result<(), SoloDawnError> {
         }
     }
 
+    // Architecture knowledge + design styles: seed builtin rows (fail-open —
+    // a seeding error must never block startup) and start the background
+    // knowledge sync loop.
+    {
+        let pool = &deployment.db().pool;
+        if let Err(e) =
+            services::services::architecture_knowledge::ensure_builtin_source(pool).await
+        {
+            tracing::warn!("Failed to seed builtin architecture source: {e}");
+        }
+        if let Err(e) = services::services::design_direction::ensure_builtin_styles(pool).await {
+            tracing::warn!("Failed to seed builtin design styles: {e}");
+        }
+        services::services::architecture_knowledge::spawn_background_sync(
+            deployment.db().pool.clone(),
+        );
+    }
+
     let cli_health_monitor = deployment.cli_health_monitor().clone();
     let app_router = routes::router(
         deployment.clone(),

--- a/crates/server/src/routes/architecture_knowledge.rs
+++ b/crates/server/src/routes/architecture_knowledge.rs
@@ -1,0 +1,281 @@
+//! Architecture knowledge API: manage GitHub knowledge sources, trigger
+//! syncs, and inspect synced entries. Guidance injection itself happens at
+//! planning-draft materialization (see `planning_drafts.rs`).
+
+use axum::{
+    Json, Router,
+    extract::{Path, Query, State},
+    routing::{get, post},
+};
+use db::models::architecture_entry::{ArchitectureEntry, ArchitectureEntrySummary};
+use db::models::architecture_source::ArchitectureSource;
+use deployment::Deployment;
+use serde::{Deserialize, Serialize};
+use services::services::architecture_knowledge;
+use utils::response::ApiResponse;
+
+use crate::{DeploymentImpl, error::ApiError};
+
+pub fn architecture_routes() -> Router<DeploymentImpl> {
+    Router::new()
+        .route("/sources", get(list_sources).post(create_source))
+        .route(
+            "/sources/{source_id}",
+            axum::routing::put(update_source).delete(delete_source),
+        )
+        .route("/sources/{source_id}/sync", post(sync_source_now))
+        .route("/entries", get(list_entries))
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceResponse {
+    pub id: String,
+    pub name: String,
+    pub owner: String,
+    pub repo: String,
+    pub branch: String,
+    pub include_paths: Vec<String>,
+    pub enabled: bool,
+    pub builtin: bool,
+    pub last_synced_at: Option<String>,
+    pub last_sync_status: Option<String>,
+    pub entry_count: i64,
+}
+
+impl SourceResponse {
+    fn from_source(source: ArchitectureSource, entry_count: i64) -> Self {
+        Self {
+            include_paths: source.include_path_list(),
+            id: source.id,
+            name: source.name,
+            owner: source.owner,
+            repo: source.repo,
+            branch: source.branch,
+            enabled: source.enabled,
+            builtin: source.builtin,
+            last_synced_at: source.last_synced_at.map(|t| t.to_rfc3339()),
+            last_sync_status: source.last_sync_status,
+            entry_count,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSourceRequest {
+    pub name: String,
+    pub owner: String,
+    pub repo: String,
+    pub branch: Option<String>,
+    pub include_paths: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateSourceRequest {
+    pub name: Option<String>,
+    pub branch: Option<String>,
+    pub include_paths: Option<Vec<String>>,
+    pub enabled: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntriesQuery {
+    pub source_id: Option<String>,
+}
+
+fn valid_github_segment(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 100
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+async fn list_sources(
+    State(deployment): State<DeploymentImpl>,
+) -> Result<Json<ApiResponse<Vec<SourceResponse>>>, ApiError> {
+    let pool = &deployment.db().pool;
+    let sources = ArchitectureSource::find_all(pool)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to list sources: {e}")))?;
+    let mut out = Vec::with_capacity(sources.len());
+    for source in sources {
+        let count = ArchitectureEntry::count_by_source(pool, &source.id)
+            .await
+            .unwrap_or(0);
+        out.push(SourceResponse::from_source(source, count));
+    }
+    Ok(Json(ApiResponse::success(out)))
+}
+
+async fn create_source(
+    State(deployment): State<DeploymentImpl>,
+    Json(req): Json<CreateSourceRequest>,
+) -> Result<Json<ApiResponse<SourceResponse>>, ApiError> {
+    let pool = &deployment.db().pool;
+    let name = req.name.trim();
+    let owner = req.owner.trim();
+    let repo = req.repo.trim();
+    let branch = req.branch.as_deref().unwrap_or("main").trim().to_string();
+    if name.is_empty() {
+        return Err(ApiError::BadRequest("Source name is required".to_string()));
+    }
+    if !valid_github_segment(owner) || !valid_github_segment(repo) {
+        return Err(ApiError::BadRequest(
+            "Owner and repo must be valid GitHub identifiers".to_string(),
+        ));
+    }
+    if branch.is_empty() || branch.len() > 200 {
+        return Err(ApiError::BadRequest("Invalid branch name".to_string()));
+    }
+    if ArchitectureSource::find_by_coords(pool, owner, repo, &branch)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .is_some()
+    {
+        return Err(ApiError::BadRequest(format!(
+            "Source {owner}/{repo}@{branch} already exists"
+        )));
+    }
+
+    let include_paths: Vec<String> = req
+        .include_paths
+        .unwrap_or_else(|| vec!["templates/".to_string()])
+        .into_iter()
+        .map(|p| p.trim().to_string())
+        .filter(|p| !p.is_empty())
+        .collect();
+    if include_paths.is_empty() {
+        return Err(ApiError::BadRequest(
+            "At least one include path is required".to_string(),
+        ));
+    }
+
+    let include_refs: Vec<&str> = include_paths.iter().map(String::as_str).collect();
+    let source = ArchitectureSource::new(name, owner, repo, &branch, &include_refs);
+    ArchitectureSource::insert(pool, &source)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to create source: {e}")))?;
+    Ok(Json(ApiResponse::success(SourceResponse::from_source(
+        source, 0,
+    ))))
+}
+
+async fn update_source(
+    State(deployment): State<DeploymentImpl>,
+    Path(source_id): Path<String>,
+    Json(req): Json<UpdateSourceRequest>,
+) -> Result<Json<ApiResponse<SourceResponse>>, ApiError> {
+    let pool = &deployment.db().pool;
+    let source = ArchitectureSource::find_by_id(pool, &source_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| ApiError::BadRequest("Source not found".to_string()))?;
+
+    let name = req
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(&source.name)
+        .to_string();
+    let branch = req
+        .branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(&source.branch)
+        .to_string();
+    let include_paths = match req.include_paths {
+        Some(paths) => {
+            let cleaned: Vec<String> = paths
+                .into_iter()
+                .map(|p| p.trim().to_string())
+                .filter(|p| !p.is_empty())
+                .collect();
+            if cleaned.is_empty() {
+                return Err(ApiError::BadRequest(
+                    "At least one include path is required".to_string(),
+                ));
+            }
+            serde_json::to_string(&cleaned)
+                .map_err(|e| ApiError::Internal(format!("Failed to encode paths: {e}")))?
+        }
+        None => source.include_paths.clone(),
+    };
+    let enabled = req.enabled.unwrap_or(source.enabled);
+
+    ArchitectureSource::update_settings(pool, &source_id, &name, &branch, &include_paths, enabled)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to update source: {e}")))?;
+
+    let updated = ArchitectureSource::find_by_id(pool, &source_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| ApiError::Internal("Source vanished during update".to_string()))?;
+    let count = ArchitectureEntry::count_by_source(pool, &source_id)
+        .await
+        .unwrap_or(0);
+    Ok(Json(ApiResponse::success(SourceResponse::from_source(
+        updated, count,
+    ))))
+}
+
+async fn delete_source(
+    State(deployment): State<DeploymentImpl>,
+    Path(source_id): Path<String>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    let pool = &deployment.db().pool;
+    let source = ArchitectureSource::find_by_id(pool, &source_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| ApiError::BadRequest("Source not found".to_string()))?;
+    if source.builtin {
+        return Err(ApiError::BadRequest(
+            "Builtin sources cannot be deleted; disable them instead".to_string(),
+        ));
+    }
+    ArchitectureSource::delete_custom(pool, &source_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to delete source: {e}")))?;
+    Ok(Json(ApiResponse::success(())))
+}
+
+async fn sync_source_now(
+    State(deployment): State<DeploymentImpl>,
+    Path(source_id): Path<String>,
+) -> Result<Json<ApiResponse<SourceResponse>>, ApiError> {
+    let pool = &deployment.db().pool;
+    let source = ArchitectureSource::find_by_id(pool, &source_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| ApiError::BadRequest("Source not found".to_string()))?;
+
+    // Errors are recorded on the source row; the refreshed row carries the
+    // outcome either way so the UI shows sync status uniformly.
+    architecture_knowledge::sync_source_recorded(pool, &source).await;
+
+    let refreshed = ArchitectureSource::find_by_id(pool, &source_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| ApiError::Internal("Source vanished during sync".to_string()))?;
+    let count = ArchitectureEntry::count_by_source(pool, &source_id)
+        .await
+        .unwrap_or(0);
+    Ok(Json(ApiResponse::success(SourceResponse::from_source(
+        refreshed, count,
+    ))))
+}
+
+async fn list_entries(
+    State(deployment): State<DeploymentImpl>,
+    Query(query): Query<EntriesQuery>,
+) -> Result<Json<ApiResponse<Vec<ArchitectureEntrySummary>>>, ApiError> {
+    let pool = &deployment.db().pool;
+    let entries = ArchitectureEntry::list_summaries(pool, query.source_id.as_deref())
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to list entries: {e}")))?;
+    Ok(Json(ApiResponse::success(entries)))
+}

--- a/crates/server/src/routes/design_styles.rs
+++ b/crates/server/src/routes/design_styles.rs
@@ -1,0 +1,259 @@
+//! Design styles API: builtin presets (license-attributed, seeded at startup)
+//! plus user-defined styles. Builtin rows accept only the `enabled` flag;
+//! users duplicate a preset into a custom style to modify its content.
+
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    routing::get,
+};
+use db::models::design_style::DesignStyle;
+use deployment::Deployment;
+use serde::{Deserialize, Serialize};
+use utils::response::ApiResponse;
+
+use crate::{DeploymentImpl, error::ApiError};
+
+/// Keep style prompts well under SQLite/text sanity bounds.
+const MAX_CONTENT_BYTES: usize = 64 * 1024;
+
+pub fn design_style_routes() -> Router<DeploymentImpl> {
+    Router::new()
+        .route("/", get(list_styles).post(create_style))
+        .route(
+            "/{style_id}",
+            axum::routing::put(update_style).delete(delete_style),
+        )
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StyleResponse {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+    pub description: String,
+    pub content: String,
+    pub source_name: Option<String>,
+    pub source_url: Option<String>,
+    pub license: Option<String>,
+    pub builtin: bool,
+    pub enabled: bool,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<DesignStyle> for StyleResponse {
+    fn from(s: DesignStyle) -> Self {
+        Self {
+            id: s.id,
+            slug: s.slug,
+            name: s.name,
+            description: s.description,
+            content: s.content,
+            source_name: s.source_name,
+            source_url: s.source_url,
+            license: s.license,
+            builtin: s.builtin,
+            enabled: s.enabled,
+            created_at: s.created_at.to_rfc3339(),
+            updated_at: s.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateStyleRequest {
+    pub name: String,
+    pub slug: Option<String>,
+    pub description: Option<String>,
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateStyleRequest {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub content: Option<String>,
+    pub enabled: Option<bool>,
+}
+
+/// Lowercase kebab slug from a display name; used when no slug is supplied.
+fn slugify(name: &str) -> String {
+    let mut slug = String::new();
+    let mut last_dash = true;
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() {
+            slug.push(c.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash {
+            slug.push('-');
+            last_dash = true;
+        }
+    }
+    let slug = slug.trim_matches('-').to_string();
+    if slug.len() >= 2 {
+        slug
+    } else {
+        format!("style-{}", &uuid::Uuid::new_v4().to_string()[..8])
+    }
+}
+
+fn valid_slug(slug: &str) -> bool {
+    slug.len() >= 2
+        && slug.len() <= 64
+        && slug
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && !slug.starts_with('-')
+        && !slug.ends_with('-')
+}
+
+fn validate_content(content: &str) -> Result<(), ApiError> {
+    if content.trim().is_empty() {
+        return Err(ApiError::BadRequest(
+            "Style content is required".to_string(),
+        ));
+    }
+    if content.len() > MAX_CONTENT_BYTES {
+        return Err(ApiError::BadRequest(format!(
+            "Style content exceeds {MAX_CONTENT_BYTES} bytes"
+        )));
+    }
+    Ok(())
+}
+
+async fn list_styles(
+    State(deployment): State<DeploymentImpl>,
+) -> Result<Json<ApiResponse<Vec<StyleResponse>>>, ApiError> {
+    let styles = DesignStyle::find_all(&deployment.db().pool)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to list design styles: {e}")))?;
+    Ok(Json(ApiResponse::success(
+        styles.into_iter().map(StyleResponse::from).collect(),
+    )))
+}
+
+async fn create_style(
+    State(deployment): State<DeploymentImpl>,
+    Json(req): Json<CreateStyleRequest>,
+) -> Result<Json<ApiResponse<StyleResponse>>, ApiError> {
+    let pool = &deployment.db().pool;
+    let name = req.name.trim();
+    if name.is_empty() {
+        return Err(ApiError::BadRequest("Style name is required".to_string()));
+    }
+    validate_content(&req.content)?;
+
+    let slug = match req.slug.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        Some(explicit) => {
+            if !valid_slug(explicit) {
+                return Err(ApiError::BadRequest(
+                    "Slug must be 2-64 chars of lowercase letters, digits and dashes".to_string(),
+                ));
+            }
+            explicit.to_string()
+        }
+        None => slugify(name),
+    };
+    if DesignStyle::find_by_slug(pool, &slug)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .is_some()
+    {
+        return Err(ApiError::BadRequest(format!(
+            "A style with slug '{slug}' already exists"
+        )));
+    }
+
+    let style = DesignStyle::new(
+        &slug,
+        name,
+        req.description.as_deref().unwrap_or("").trim(),
+        req.content.trim(),
+    );
+    DesignStyle::insert(pool, &style)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to create style: {e}")))?;
+    Ok(Json(ApiResponse::success(style.into())))
+}
+
+async fn update_style(
+    State(deployment): State<DeploymentImpl>,
+    Path(style_id): Path<String>,
+    Json(req): Json<UpdateStyleRequest>,
+) -> Result<Json<ApiResponse<StyleResponse>>, ApiError> {
+    let pool = &deployment.db().pool;
+    let style = DesignStyle::find_by_id(pool, &style_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| ApiError::BadRequest("Style not found".to_string()))?;
+
+    if style.builtin {
+        // Builtin presets: only the enabled flag is mutable.
+        if req.name.is_some() || req.description.is_some() || req.content.is_some() {
+            return Err(ApiError::BadRequest(
+                "Builtin styles cannot be edited; duplicate into a custom style instead"
+                    .to_string(),
+            ));
+        }
+        if let Some(enabled) = req.enabled {
+            DesignStyle::set_enabled(pool, &style_id, enabled)
+                .await
+                .map_err(|e| ApiError::Internal(format!("Failed to update style: {e}")))?;
+        }
+    } else {
+        let name = req
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&style.name)
+            .to_string();
+        let description = req
+            .description
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or(&style.description)
+            .to_string();
+        let content = match req.content.as_deref() {
+            Some(c) => {
+                validate_content(c)?;
+                c.trim().to_string()
+            }
+            None => style.content.clone(),
+        };
+        let enabled = req.enabled.unwrap_or(style.enabled);
+        DesignStyle::update_custom(pool, &style_id, &name, &description, &content, enabled)
+            .await
+            .map_err(|e| ApiError::Internal(format!("Failed to update style: {e}")))?;
+    }
+
+    let updated = DesignStyle::find_by_id(pool, &style_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| ApiError::Internal("Style vanished during update".to_string()))?;
+    Ok(Json(ApiResponse::success(updated.into())))
+}
+
+async fn delete_style(
+    State(deployment): State<DeploymentImpl>,
+    Path(style_id): Path<String>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    let pool = &deployment.db().pool;
+    let style = DesignStyle::find_by_id(pool, &style_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| ApiError::BadRequest("Style not found".to_string()))?;
+    if style.builtin {
+        return Err(ApiError::BadRequest(
+            "Builtin styles cannot be deleted; disable them instead".to_string(),
+        ));
+    }
+    DesignStyle::delete_custom(pool, &style_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to delete style: {e}")))?;
+    Ok(Json(ApiResponse::success(())))
+}

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -63,6 +63,7 @@ fn build_cors_layer() -> CorsLayer {
 }
 
 pub mod approvals;
+pub mod architecture_knowledge;
 pub mod chat_integrations;
 pub mod ci_webhook;
 pub mod cli_status_sse;
@@ -72,6 +73,7 @@ pub mod concierge_ws;
 pub mod config;
 pub mod containers;
 pub mod custom_rules;
+pub mod design_styles;
 pub mod filesystem;
 pub mod event_bridge;
 pub mod events;
@@ -164,6 +166,11 @@ pub fn build_router(
         .nest("/cli_types", cli_types::cli_types_routes())
         .nest("/cli_types", cli_status_sse::cli_status_sse_routes())
         .nest("/planning-drafts", planning_drafts::planning_draft_routes())
+        .nest(
+            "/architecture",
+            architecture_knowledge::architecture_routes(),
+        )
+        .nest("/design-styles", design_styles::design_style_routes())
         .nest("/workflows", workflows::workflows_routes())
         .nest("/workflows", slash_commands::slash_commands_routes())
         .nest("/workflows", provider_health::provider_health_routes())

--- a/crates/server/src/routes/planning_drafts.rs
+++ b/crates/server/src/routes/planning_drafts.rs
@@ -37,6 +37,15 @@ pub struct CreateDraftRequest {
     pub planner_api_type: Option<String>,
     pub planner_base_url: Option<String>,
     pub planner_api_key: Option<String>,
+    pub design_style_slug: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateDesignStyleRequest {
+    /// Style slug to apply; `None`/empty clears the selection so the system
+    /// default (or none) applies at materialization.
+    pub design_style_slug: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -75,6 +84,7 @@ pub struct DraftResponse {
     pub audit_plan: Option<String>,
     pub audit_mode: String,
     pub audit_doc_path: Option<String>,
+    pub design_style_slug: Option<String>,
     pub gates_confirmed_at: Option<String>,
     pub created_at: String,
     pub updated_at: String,
@@ -100,6 +110,7 @@ impl From<PlanningDraft> for DraftResponse {
             audit_plan: d.audit_plan,
             audit_mode: d.audit_mode,
             audit_doc_path: d.audit_doc_path,
+            design_style_slug: d.design_style_slug,
             gates_confirmed_at: d.gates_confirmed_at.map(|t| t.to_rfc3339()),
             created_at: d.created_at.to_rfc3339(),
             updated_at: d.updated_at.to_rfc3339(),
@@ -167,6 +178,7 @@ pub fn planning_draft_routes() -> Router<DeploymentImpl> {
         .route("/{draft_id}/confirm", post(confirm_draft))
         .route("/{draft_id}/confirm-gates", post(confirm_gates))
         .route("/{draft_id}/continue", post(continue_draft))
+        .route("/{draft_id}/design-style", put(update_design_style))
         .route("/{draft_id}/materialize", post(materialize_draft))
         .route("/{draft_id}/feishu-sync", post(toggle_feishu_sync))
         .route(
@@ -192,6 +204,10 @@ async fn create_draft(
     draft.planner_model_id = req.planner_model_id;
     draft.planner_api_type = req.planner_api_type;
     draft.planner_base_url = req.planner_base_url;
+    draft.design_style_slug = req
+        .design_style_slug
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
     if let Some(ref api_key) = req.planner_api_key {
         draft
             .set_api_key(api_key)
@@ -550,6 +566,51 @@ async fn confirm_gates(
 /// - the parent's workflow must be in a terminal state — one active round at
 ///   a time on a repository;
 /// - the parent must not already have a continuation (linear chain).
+async fn update_design_style(
+    State(deployment): State<DeploymentImpl>,
+    Path(draft_id): Path<String>,
+    Json(req): Json<UpdateDesignStyleRequest>,
+) -> Result<ResponseJson<ApiResponse<DraftResponse>>, ApiError> {
+    let pool = &deployment.db().pool;
+    let draft = PlanningDraft::find_by_id(pool, &draft_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| ApiError::NotFound(format!("Planning draft {draft_id} not found")))?;
+
+    if draft.status == "materialized" || draft.status == "cancelled" {
+        return Err(ApiError::BadRequest(format!(
+            "Cannot change the design style of a draft in status '{}'",
+            draft.status
+        )));
+    }
+
+    let slug = req
+        .design_style_slug
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    if let Some(ref slug) = slug {
+        let style = db::models::design_style::DesignStyle::find_by_slug(pool, slug)
+            .await
+            .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+            .ok_or_else(|| ApiError::BadRequest(format!("Unknown design style '{slug}'")))?;
+        if !style.enabled {
+            return Err(ApiError::BadRequest(format!(
+                "Design style '{slug}' is disabled"
+            )));
+        }
+    }
+
+    PlanningDraft::update_design_style(pool, &draft_id, slug.as_deref())
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to update design style: {e}")))?;
+
+    let updated = PlanningDraft::find_by_id(pool, &draft_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| ApiError::Internal("Draft vanished during update".to_string()))?;
+    Ok(Json(ApiResponse::success(DraftResponse::from(updated))))
+}
+
 async fn continue_draft(
     State(deployment): State<DeploymentImpl>,
     Path(draft_id): Path<String>,
@@ -603,6 +664,8 @@ async fn continue_draft(
     child.planner_api_type = parent.planner_api_type.clone();
     child.planner_base_url = parent.planner_base_url.clone();
     child.planner_api_key = parent.planner_api_key.clone();
+    // Rounds keep a consistent visual direction unless the user changes it.
+    child.design_style_slug = parent.design_style_slug.clone();
 
     PlanningDraft::insert(&deployment.db().pool, &child)
         .await
@@ -1208,6 +1271,42 @@ async fn materialize_draft(
         }
     } else {
         initial_goal
+    };
+
+    // Architecture guidance rides inside the goal like the ledger background:
+    // a self-answered methodology checklist plus digests of the reference
+    // templates matched against the requirement text. Fail-open — a missing
+    // knowledge base degrades to methodology-only or no section at all.
+    let matching_text = format!(
+        "{requirement_summary} {}",
+        draft.technical_spec.as_deref().unwrap_or("")
+    );
+    let initial_goal = match services::services::architecture_knowledge::build_architecture_context(
+        &deployment.db().pool,
+        &matching_text,
+    )
+    .await
+    {
+        Some(section) => initial_goal
+            .map(|g| format!("{g}\n\n---\n\n{section}"))
+            .or(Some(section)),
+        None => initial_goal,
+    };
+
+    // Design direction: the draft's selected style, else the system default.
+    let initial_goal = match services::services::design_direction::resolve_style(
+        &deployment.db().pool,
+        draft.design_style_slug.as_deref(),
+    )
+    .await
+    {
+        Some(style) => {
+            let section = services::services::design_direction::build_design_direction_section(&style);
+            initial_goal
+                .map(|g| format!("{g}\n\n---\n\n{section}"))
+                .or(Some(section))
+        }
+        None => initial_goal,
     };
 
     // Use the first user-configured model for merge terminal defaults.

--- a/crates/server/src/routes/system_settings.rs
+++ b/crates/server/src/routes/system_settings.rs
@@ -12,8 +12,17 @@ use crate::{
 };
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct UpdateSettings {
+    // Accept the historical snake_case field name alongside camelCase so
+    // existing callers keep working.
+    #[serde(alias = "feishu_enabled")]
     feishu_enabled: Option<bool>,
+    /// Toggles the architecture-guidance section injected at materialization.
+    architecture_guidance_enabled: Option<bool>,
+    /// Fallback design style slug applied when a draft has no selection;
+    /// empty string clears the default.
+    default_design_style: Option<String>,
 }
 
 pub fn router() -> Router<DeploymentImpl> {
@@ -68,6 +77,26 @@ async fn update_settings(
         )
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to update feishu_enabled: {e}")))?;
+    }
+    if let Some(enabled) = body.architecture_guidance_enabled {
+        SystemSetting::set(
+            pool,
+            services::services::architecture_knowledge::SETTING_GUIDANCE_ENABLED,
+            if enabled { "true" } else { "false" },
+        )
+        .await
+        .map_err(|e| {
+            ApiError::Internal(format!("Failed to update architecture_guidance_enabled: {e}"))
+        })?;
+    }
+    if let Some(slug) = body.default_design_style {
+        SystemSetting::set(
+            pool,
+            services::services::design_direction::SETTING_DEFAULT_STYLE,
+            slug.trim(),
+        )
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to update default_design_style: {e}")))?;
     }
     // Return updated settings
     get_settings(State(deployment)).await

--- a/crates/services/assets/architecture/methodology.md
+++ b/crates/services/assets/architecture/methodology.md
@@ -1,0 +1,36 @@
+<!--
+Adapted from the "architecture-copilot" skill in study8677/architecture-copilot
+Source: https://github.com/study8677/architecture-copilot
+License: MIT. See the SoloDawn LICENSE file for full attribution.
+Changes: condensed and adapted for automated prompt injection (2026-07-04).
+-->
+
+# Architecture Thinking Checklist
+
+Apply this checklist to the requirement text before decomposing work. Answer every item yourself; where requirements are silent, state an explicit assumption and proceed. Three beliefs: architecture is forced out of constraints, not drawn; no silver bullets, only tradeoffs — a plan with no stated downside is not thought through; no best architecture, only the most fitting under this constraint set.
+
+0. Positioning. One sentence: what this is, for whom, and which existing product it most resembles.
+
+1. Scope reduction. Write an explicit MVP do/don't list. Every item cut makes the architecture an order of magnitude simpler. Separate functional requirements (what) from quality attributes (how well); the latter plus constraints usually decide the architecture.
+
+2. Six soul questions — answer each from requirements or record an assumption:
+   - Scale: users/data now and at peak? (when to prepare for scale)
+   - Read/write ratio? (which side to optimize for)
+   - Consistency: must a write be immediately readable, or is brief staleness tolerable?
+   - Growth: size in a year — gradual or explosive? (how much headroom)
+   - Cost of failure: outage, lost data, wrong charge — how bad? (reliability and audit spend)
+   - Constraints: team, time, budget, compliance, existing systems? (constraints kill options)
+
+3. Back-of-envelope estimates (orders of magnitude): write QPS ~ daily writes / 100k; read QPS = ratio x write QPS; peak ~ 3x average; storage/year ~ item size x daily volume x 365. For AI/LLM features also estimate tokens per request, calls per task, first-token latency, per-call and daily cost, agent loop and fan-out caps. Then name the component that dies first (reads, writes, storage, bandwidth, GPU, queue, human review, cost) and concentrate design effort there.
+
+4. Quality attribute ranking. Rank performance, availability, durability, scalability, consistency, security, cost, maintainability, observability, evolvability; for each top attribute, name what is knowingly sacrificed. "All equally important" means the analysis is unfinished.
+
+5. Key decision forks. For each major choice record: "chose X over Y because Z; cost is W." Typical forks: storage by access shape (relational/KV/vector/object/inverted index/log); sync vs async on the critical path; cache or not, and how stale; state on client or server; monolith vs split — default to a modular monolith; microservices solve people-scaling first.
+
+6. Convergence outputs, in order: data model first (data | access shape | store | consistency | why); ASCII container diagram (context black box plus external dependencies, then 5-6 containers with directional, meaningful arrows); ADR one-liners (decision/reason/cost/trigger signal); the first bottleneck at 100x load and its fix; an MVP-first evolution route (MVP, growth, maturity — never force the mature design onto the MVP).
+
+7. Self-challenge — attack the plan: consistency and idempotency (double writes, retries, duplicate charges, reconciliation); resilience (dependency down, timeouts, backoff, circuit breaking, degradation); hot spots (fan-out, P99 tails, queue buildup, cache stampede, single shard/GPU); security and multi-tenancy (authz, tenant isolation, secrets, audit boundaries); AI-specific risks (hallucination, prompt injection, cost drift, missing evals); which single assumption, if wrong, hurts most.
+
+Default to simple; upgrade only on signals: P95/P99 sustained over target, error budget burning, write QPS or single-store limits approached, releases blocking each other, per-task AI cost drifting, eval regressions. No signal: stay with the modular monolith. On signal: write an ADR with reason, alternative, and rollback path.
+
+Fold the resulting decisions into the task instructions for implementing agents: one unified tech stack, shared data models defined once and referenced everywhere, and explicit module boundaries with named interfaces — so parallel work composes instead of colliding.

--- a/crates/services/assets/design_styles/anthropic-frontend-design.md
+++ b/crates/services/assets/design_styles/anthropic-frontend-design.md
@@ -1,0 +1,56 @@
+<!--
+Adapted from the "frontend-design" skill in anthropics/skills
+Source: https://github.com/anthropics/skills
+License: Apache-2.0. See the SoloDawn LICENSE file for full attribution.
+Changes: condensed and adapted for automated prompt injection (2026-07-04).
+-->
+
+# Frontend Design
+
+Approach this as the design lead at a small studio known for giving every client a visual identity that could not be mistaken for anyone else's. This client has already rejected proposals that felt templated, and is paying for a distinctive point of view: make deliberate, opinionated choices about palette, typography, and layout that are specific to this brief, and take one real aesthetic risk you can justify.
+
+## Ground it in the subject
+
+If the brief does not pin down what the product or subject is, pin it yourself before designing: name one concrete subject, its audience, and the page's single job, and state your choice. If there's any information in your memory about the human's preferences, context about what they're building, or designs you've made before – use that as a hint. The subject's own world, its materials, instruments, artifacts, and vernacular, is where distinctive choices come from. Build with the brief's real content and subject matter throughout.
+
+## Design principles
+
+For web designs, the hero is a thesis. Open with the most characteristic thing in the subject's world, in whatever form makes sense for it: a headline, an image, an animation, a live demo, an interactive moment. Be deliberate with your choice: a big number with a small label, supporting stats, and a gradient accent is the template answer, only use if that's truly the best option.
+
+Typography carries the personality of the page. Pair the display and body faces deliberately, not the same families you would reach for on any other project, and set a clear type scale with intentional weights, widths, and spacing. Make the type treatment itself a memorable part of the design, not a neutral delivery vehicle for the content.
+
+Structure is information. Structural devices, numbering, eyebrows, dividers, labels, should encode something true about the content, not decorate it. Many generic designs use numbered markers (01 / 02 / 03), but that's only appropriate if the content actually is a sequence - like a real process or a typed timeline where order carries information the reader needs. Question if choices like numbered markers actually make sense before incorporating them.
+
+Leverage motion deliberately. Think about where and if animation can serve the subject: a page-load sequence, a scroll-triggered reveal, hover micro-interactions, ambient atmosphere. An orchestrated moment usually lands harder than scattered effects; choose what the direction calls for. However, sometimes less is more, and extra animation contributes to the feeling that the design is AI-generated.
+
+Match complexity to the vision. Maximalist directions need elaborate execution; minimal directions need precision in spacing, type, and detail. Elegance is executing the chosen vision well.
+
+Consider written content carefully. Often a design brief may not contain real content, and it's up to you to come up with copy. Copy can make a design feel as templated as the design itself. See the below section on writing for more guidance.
+
+## Process: brainstorm, explore, plan, critique, build, critique again
+
+For calibration: AI-generated design right now clusters around three looks: (1) a warm cream background (near #F4F1EA) with a high-contrast serif display and a terracotta accent; (2) a near-black background with a single bright acid-green or vermilion accent; (3) a broadsheet-style layout with hairline rules, zero border-radius, and dense newspaper-like columns. All three are legitimate for some briefs, but they are defaults rather than choices, and they appear regardless of subject. Where the brief pins down a visual direction, follow it exactly — the brief's own words always win, including when it asks for one of these looks. Where it leaves an axis free, don't spend that freedom on one of these defaults. Just like a human designer who's hired, there's often a careful balance between doing what you're good at and taking each project as a chance to experiment and learn.
+
+Work in two passes. First, brainstorm a short design plan based on the human's design brief: create a compact token system with color, type, layout, and signature. Color: describe the palette as 4–6 named hex values. Type: the typefaces for 2+ roles (a characterful display face that's used with restraint, a complementary body face, and a utility face for captions or data if needed). Layout: a layout concept, using one-sentence prose descriptions and ASCII wireframes to ideate and compare. Signature: the single unique element this page will be remembered by that embodies the brief in an appropriate way.
+
+Then review that plan against the brief before building: if any part of it reads like the generic default you would produce for any similar page (work through a similar prompt to see if you arrive somewhere similar) rather than a choice made for this specific brief — revise that part, say what you changed and why. Only after you've confirmed the relative uniqueness of your design plan should you start to write the code, following the revised plan exactly and deriving every color and type decision from it.
+
+When writing the code, be careful of structuring your CSS selector specificities. It's easy to generate CSS classes that cancel each other out (especially with a type-based selector like .section and a element-based selector like .cta). This can happen often with paddings/margins between sections.
+
+Try to do a lot of this planning and iteration in your thinking, and only show ideas to the user when you have higher confidence it'll delight them.
+
+## Restraint and self-critique
+
+Spend your boldness in one place. Let the signature element be the one memorable thing, keep everything around it quiet and disciplined, and cut any decoration that does not serve the brief. Not taking a risk can be a risk itself! Build to a quality floor without announcing it: responsive down to mobile, visible keyboard focus, reduced motion respected. Critique your own work as you build, taking screenshots if your environment supports it – a picture is worth 1000 tokens. Consider Chanel's advice: before leaving the house, take a look in the mirror and remove one accessory. Human creators have memory and always try to do something new, so if you have a space to quickly jot down notes about what you've tried, it can help you in future passes.
+
+## More on writing in design
+
+Words appear in a design for one reason: to make it easier to understand, and therefore easier to use. They are design material, not decoration. Bring the same intentionality to copy that you would bring to spacing and color. Before writing anything, ask what the design needs to say, and how it can best be said to help the person navigate the experience.
+
+Write from the end user's side of the screen. Name things by what people control and recognize, never by how the system is built. A person manages notifications, not webhook config. Describe what something does in plain terms rather than selling it. Being specific is always better than being clever.
+
+Use active voice as default. A control should say exactly what happens when it's used: "Save changes," not "Submit." An action keeps the same name through the whole flow, so the button that says "Publish" produces a toast that says "Published." The vocabulary of an interface is the signposting for someone navigating the product. Cohesion and consistency are how people learn their way around.
+
+Treat failure and emptiness as moments for direction, not mood. Explain what went wrong and how to fix it, in the interface's voice rather than a person's. Errors don't apologize, and they are never vague about what happened. An empty screen is an invitation to act.
+
+Keep the register conversational and tuned: plain verbs, sentence case, no filler, with tone matched to the brand and the audience. Let each element do exactly one job. A label labels, an example demonstrates, and nothing quietly does double duty.

--- a/crates/services/assets/design_styles/emil-design-engineering.md
+++ b/crates/services/assets/design_styles/emil-design-engineering.md
@@ -1,0 +1,83 @@
+<!--
+Adapted from the "emil-design-eng" skill in emilkowalski/skills
+Source: https://github.com/emilkowalski/skills
+License: MIT. See the SoloDawn LICENSE file for full attribution.
+Changes: condensed and adapted for automated prompt injection (2026-07-04).
+-->
+
+# Design Engineering: Animation and Interaction Craft
+
+Build interfaces where every detail compounds into something that feels right. Most details are never consciously noticed — that is the point: the aggregate of invisible correctness creates interfaces people love without knowing why. Beauty is leverage: good defaults and good animations are real differentiators.
+
+## Decide whether to animate
+
+Ask how often users will see it: 100+ times/day (keyboard shortcuts, command palette) — no animation, ever; tens of times/day (hover, list navigation) — remove or drastically reduce; occasional (modals, drawers, toasts) — standard; rare or first-time (onboarding, celebrations) — can add delight.
+
+Never animate keyboard-initiated actions: they repeat hundreds of times daily, and animation makes them feel slow and disconnected.
+
+Every animation must answer "why does this animate?" Valid purposes: spatial consistency (a toast enters and exits from the same direction), state indication, explanation, feedback (a button scales down on press), preventing jarring appearance/disappearance. If the purpose is only "it looks cool" and users see it often, do not animate.
+
+## Easing
+
+- Entering or exiting: ease-out (starts fast, feels responsive). Moving or morphing on screen: ease-in-out. Hover or color change: ease. Constant motion (marquee, progress bar): linear. Default: ease-out.
+- Built-in CSS easings are too weak; use custom curves:
+  - `--ease-out: cubic-bezier(0.23, 1, 0.32, 1);`
+  - `--ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);`
+  - `--ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);` (iOS-like drawer curve)
+- Never use ease-in for UI animations: it delays the initial movement at the exact moment the user is watching most closely, so the interface feels sluggish.
+
+## Duration
+
+Button press feedback 100-160ms; tooltips and small popovers 125-200ms; dropdowns and selects 150-250ms; modals and drawers 200-500ms; marketing/explanatory can be longer. Keep UI animations under 300ms.
+
+Perceived speed matters as much as actual speed: a 180ms select feels more responsive than a 400ms one; a fast-spinning spinner makes loading feel faster; ease-out at 200ms feels faster than ease-in at 200ms because the user sees immediate movement.
+
+## Springs
+
+Use springs for drag interactions with momentum, elements that should feel alive, interruptible gestures, and decorative mouse-tracking (interpolate through a spring instead of tracking position directly; if the element is functional, no animation is better). Prefer `{ type: "spring", duration: 0.5, bounce: 0.2 }` over raw mass/stiffness/damping. Keep bounce subtle (0.1-0.3); avoid it outside drag-to-dismiss and playful moments. Springs maintain velocity when interrupted — CSS keyframes restart from zero — ideal for gestures users may reverse mid-motion.
+
+## Component rules
+
+- Every pressable element: `transform: scale(0.97)` on `:active` with `transition: transform 160ms ease-out`; keep the scale subtle (0.95-0.98).
+- Never animate from `scale(0)`: nothing real appears from nothing. Start from `scale(0.9)` or higher, combined with `opacity: 0`.
+- Popovers scale in from their trigger, not center: set `transform-origin` to the trigger side (Radix: `var(--radix-popover-content-transform-origin)`). Modals are the exception — keep them centered.
+- Tooltips: delay the first; open adjacent ones instantly with no delay and no animation.
+- Use CSS transitions over keyframes for anything rapidly triggered (toasts, toggles): transitions retarget smoothly mid-flight; keyframes restart from zero.
+- When a crossfade feels off despite easing and duration changes, add `filter: blur(2px)` during the transition: blur blends the two overlapping states into one perceived transformation. Keep blur under 20px — heavy blur is expensive, especially in Safari.
+- Animate entry with `@starting-style` where supported; otherwise fall back to a `data-mounted` attribute set after first render.
+
+## Transforms and clip-path
+
+- Prefer percentage translates: `translateY(100%)` moves an element by its own height — less error-prone than pixels for drawers and toasts.
+- `scale()` scales children too (text, icons); that is a feature, not a bug.
+- `clip-path: inset()` is a first-class animation tool: reveal with `inset(0 100% 0 0)` to `inset(0 0 0 0)`; image reveals on scroll from `inset(0 0 100% 0)`; comparison sliders by driving one inset from drag position. Hold-to-delete: the press fills a clipped overlay over 2s linear; release snaps back in 200ms ease-out.
+
+## Gestures and drag
+
+- Momentum dismissal: velocity = |dragDistance| / elapsedTime; dismiss when velocity exceeds ~0.11 even below the distance threshold — a quick flick is enough.
+- Past a natural boundary, apply damping — the more the user drags, the less it moves; prefer friction over hard stops.
+- Capture pointer events once dragging starts; ignore additional touch points mid-drag.
+
+## Performance
+
+- Animate only `transform` and `opacity` — they skip layout and paint.
+- Do not drive per-frame motion through a CSS variable on a parent (it recalculates styles for all children); set `transform` directly on the element.
+- Framer Motion shorthand props (`x`, `y`, `scale`) are not hardware-accelerated; use the full `transform` string when frames must hold under load.
+- CSS animations run off the main thread and stay smooth while the browser is busy: use CSS for predetermined animations, JS for dynamic ones, and the Web Animations API for programmatic control with CSS performance.
+
+## Accessibility
+
+- `prefers-reduced-motion` means fewer and gentler animations, not zero: keep opacity and color transitions that aid comprehension; remove movement.
+- Gate hover effects behind `@media (hover: hover) and (pointer: fine)` — touch devices trigger hover on tap.
+
+## Taste rules
+
+- Good defaults matter more than options: easing, timing, and visual design must be excellent out of the box.
+- Handle edge cases invisibly: pause timers when the tab is hidden, fill hover gaps between stacked items, protect drags from multi-touch.
+- Cohesion: match motion to the component's personality — playful components can be bouncier; professional dashboards should be crisp and fast.
+- Asymmetric timing: slow where the user is deciding, fast where the system responds (press 2s linear, release 200ms ease-out). Exits generally faster than entrances.
+- Stagger simultaneous entrances by 30-80ms per item; stagger is decorative — never block interaction while it plays.
+
+## Self-review checklist
+
+`transition: all` — name exact properties. `scale(0)` entry — `scale(0.95)` + `opacity: 0`. `ease-in` on UI — ease-out or custom curve. Centered popover origin — trigger-aware (modals exempt). Animation on a keyboard action — remove. UI duration over 300ms — cut to 150-250ms. Hover without the media query — gate it. Keyframes on rapid elements — transitions. Same enter/exit speed — exit faster. Everything at once — stagger 30-80ms.

--- a/crates/services/assets/design_styles/impeccable-design-language.md
+++ b/crates/services/assets/design_styles/impeccable-design-language.md
@@ -1,0 +1,71 @@
+<!--
+Adapted from the "impeccable" skill in pbakaus/impeccable
+Source: https://github.com/pbakaus/impeccable
+License: Apache-2.0. See the SoloDawn LICENSE file for full attribution.
+Changes: condensed and adapted for automated prompt injection (2026-07-04).
+-->
+
+# Impeccable Design Language
+
+Produce ready-to-ship, production-grade interfaces, not prototypes or starting points. Do not stop until the implementation is complete: beautiful, responsive, fast, precise, bug-free, on brand. Take attention to detail seriously — the rules below are non-negotiable.
+
+## Color
+
+- Verify contrast. Body text must hit at least 4.5:1 against its background; large text (18px+, or bold 14px+) needs at least 3:1. Placeholder text needs the same 4.5:1, not the muted-gray default. The most common failure is muted gray body text on a tinted near-white: if contrast is even close, bump the body color toward the ink end of the ramp. Light gray "for elegance" is the single biggest reason AI designs feel hard to read.
+- Gray text on a colored background looks washed out. Use a darker shade of the background's own hue, or a transparency of the text color.
+
+## Typography
+
+- Cap body line length at 65-75ch.
+- Never pair fonts that are similar but not identical (two geometric sans-serifs, two humanist sans-serifs). Pair on a contrast axis (serif + sans, geometric + humanist) or use one family in multiple weights.
+- Hero/display heading ceiling: clamp() max <= 6rem (~96px). Above that the page is shouting, not designing.
+- Display heading letter-spacing floor: >= -0.04em. Anything tighter and letters touch — cramped, not "designed".
+- Use `text-wrap: balance` on h1-h3 for even line lengths; `text-wrap: pretty` on long prose to reduce orphans.
+
+## Layout
+
+- Vary spacing for rhythm.
+- Cards are the lazy answer. Use them only when they are truly the best affordance. Nested cards are always wrong.
+- Flexbox for 1D, Grid for 2D; do not default to Grid when `flex-wrap` would be simpler. Responsive grids without breakpoints: `repeat(auto-fit, minmax(280px, 1fr))`.
+- Build a semantic z-index scale (dropdown, sticky, modal-backdrop, modal, toast, tooltip). Never arbitrary values like 999 or 9999.
+
+## Motion
+
+- Motion is part of the build, not an afterthought. Do not animate CSS layout properties unless truly needed.
+- Ease out with exponential curves (ease-out-quart / quint / expo). No bounce, no elastic. Use libraries (motion, gsap, anime.js, lenis) for advanced needs.
+- Reduced motion is not optional: every animation needs a `@media (prefers-reduced-motion: reduce)` alternative — typically a crossfade or instant transition.
+- Staggering items within one list is legitimate. The tell is the uniform reflex (one identical entrance applied to every section), not motion itself; each reveal should fit what it reveals. Never ship a page with no motion at all for fear of this.
+- Reveal animations must enhance an already-visible default. Never gate content visibility on a class-triggered transition: transitions pause in hidden tabs and headless renderers, and the section ships blank.
+- Premium motion materials go beyond transform/opacity: blur, backdrop-filter, clip-path, mask, and shadow/glow belong in the palette when they materially improve the effect and stay smooth.
+
+## Interaction
+
+- Dropdowns rendered with `position: absolute` inside an `overflow: hidden` or `overflow: auto` container get clipped. Use the native `<dialog>` / popover API, `position: fixed`, or a portal to escape the stacking context.
+
+## Color and theme for new projects
+
+- Use OKLCH throughout.
+- The cream/sand/beige body background is the saturated AI default. The whole warm-neutral band (OKLCH L 0.84-0.97, C < 0.06, hue 40-100) reads as cream/paper/parchment regardless of name, and token names like `--paper`, `--cream`, `--sand`, `--bone`, `--linen`, `--parchment`, `--ivory` are tells in themselves. Do not translate "warm / editorial / traditional" briefs into a near-white warm-tinted background. Pick instead: (a) a saturated brand color as the body (terracotta, oxblood, deep ochre, near-black); (b) a true off-white at chroma 0, or chroma toward the brand's own hue; or (c) a darker mid-tone tinted neutral that is clearly the brand's own. Warmth is carried by accent + typography + imagery, not by the body background.
+- Tinted neutrals: add 0.005-0.015 chroma toward the brand's hue. Never default-tint warm or cool "because the brand feels that way".
+- Dark vs. light is never a default — not dark "because tools look cool dark", not light "to be safe". Before choosing, write one sentence of physical scene: who uses this, where, under what ambient light, in what mood. If the sentence does not force the answer, add detail until it does.
+- Pick a color strategy before picking colors: Restrained (tinted neutrals + one accent <= 10%; product default), Committed (one saturated color carries 30-60% of the surface; identity-driven pages), Full palette (3-4 named roles, each used deliberately), Drenched (the surface IS the color; brand heroes, campaign pages).
+
+## Absolute bans
+
+If about to write any of these, rewrite the element with different structure:
+
+- Side-stripe borders: `border-left` or `border-right` greater than 1px as a colored accent on cards, list items, callouts, or alerts. Never intentional. Rewrite with full borders, background tints, leading numbers/icons, or nothing.
+- Gradient text: `background-clip: text` combined with a gradient. Use a single solid color; emphasis via weight or size.
+- Glassmorphism as default: blurs and glass cards used decoratively. Rare and purposeful, or nothing.
+- The hero-metric template: big number, small label, supporting stats, gradient accent. SaaS cliche.
+- Identical card grids: same-sized cards with icon + heading + text, repeated endlessly.
+- A tiny uppercase tracked eyebrow above every section: one named kicker as a deliberate brand system is voice; an eyebrow on every section is AI grammar. Choose a different cadence.
+- Numbered section markers (01 / 02 / 03) as default scaffolding: numbers earn their place only when the section actually IS a sequence and the order carries information the reader needs.
+- Text that overflows its container: test heading copy at every breakpoint; if it overflows, reduce the clamp max or rewrite the copy. The viewport is part of the design.
+
+## The AI slop test
+
+If someone could look at this interface and say "AI made that" without doubt, it has failed. Run the category-reflex check at two altitudes:
+
+- First-order: if someone could guess the theme + palette from the category alone, it is the first training-data reflex. Rework the scene sentence and color strategy until the answer is not obvious from the domain.
+- Second-order: if someone could guess the aesthetic family from category-plus-anti-references ("AI workflow tool that's not SaaS-cream, so editorial-typographic"; "fintech that's not navy-and-gold, so terminal-native dark mode"), it is the trap one tier deeper. Rework until both answers are non-obvious.

--- a/crates/services/assets/design_styles/taste-industrial-brutalist.md
+++ b/crates/services/assets/design_styles/taste-industrial-brutalist.md
@@ -1,0 +1,63 @@
+<!--
+Adapted from the "industrial-brutalist-ui" skill in Leonxlnx/taste-skill
+Source: https://github.com/Leonxlnx/taste-skill
+License: MIT. See the SoloDawn LICENSE file for full attribution.
+Changes: condensed and adapted for automated prompt injection (2026-07-04).
+-->
+
+# Industrial Brutalism and Tactical Telemetry UI
+
+Architect web interfaces that synthesize mid-century Swiss typographic design, industrial manufacturing manuals, and retro-futuristic aerospace/military terminal interfaces. Enforce rigid modular grids, extreme typographic scale contrast, purely utilitarian color, and programmatic simulation of analog degradation (halftones, CRT scanlines, bitmap dithering). The result must project raw functionality, mechanical precision, and high data density, deliberately discarding conventional consumer UI patterns.
+
+## Visual archetypes — pick ONE per project and commit
+
+Never alternate or mix both modes within the same interface.
+
+- Swiss Industrial Print: high-contrast light mode on newsprint/off-white substrates; monolithic, heavy sans-serif typography; unforgiving structural grids outlined by visible dividing lines; aggressive, asymmetric negative space punctuated by oversized, viewport-bleeding numerals or letterforms; heavy use of primary red as the alert/accent color.
+- Tactical Telemetry / CRT Terminal: dark mode exclusively; high-density tabular data presentation; absolute dominance of monospaced typography; technical framing devices (ASCII brackets, crosshairs); simulated hardware limitations (phosphor glow, scanlines, low bit-depth rendering).
+
+## Typographic architecture
+
+Typography is the primary structural and decorative infrastructure; imagery is secondary. Demand extreme variance in scale, weight, and spacing.
+
+- Macro-typography (structural headers): neo-grotesque / heavy sans-serif — Neue Haas Grotesk (Black), Inter (Extra Bold/Black), Archivo Black, Roboto Flex (Heavy), Monument Extended. Deploy at massive fluid scales (`clamp(4rem, 10vw, 15rem)`); tracking extremely tight, often negative (`-0.03em` to `-0.06em`) so glyphs form solid architectural blocks; line-height highly compressed (`0.85` to `0.95`); exclusively uppercase.
+- Micro-typography (data and telemetry): monospace / technical sans — JetBrains Mono, IBM Plex Mono, Space Mono, VT323, Courier Prime. Fixed small scale (`10px` to `14px`); generous tracking (`0.05em` to `0.1em`) to simulate typewriter or terminal matrices; leading `1.2` to `1.4`; exclusively uppercase. Use for all metadata, navigation, unit IDs, and coordinates.
+- Textural contrast (use exceedingly sparingly): high-contrast serif — Playfair Display, EB Garamond, Times New Roman — always subjected to heavy post-processing (halftone filters, 1-bit dithering) to degrade vector perfection against the clean sans-serifs.
+
+## Color system — choose ONE substrate palette, never mix
+
+Gradients, soft drop shadows, and modern translucency are strictly prohibited. Colors simulate physical media or primitive emissive displays.
+
+- Swiss Industrial Print (light): background `#F4F4F0` or `#EAE8E3` (matte, unbleached documentation paper); foreground `#050505` to `#111111` (carbon ink); accent `#E61919` or `#FF2A2A` (aviation/hazard red) — the ONLY accent color, used for strike-throughs, thick structural dividing lines, or vital data highlights.
+- Tactical Telemetry (dark): background `#0A0A0A` or `#121212` (deactivated CRT — avoid pure `#000000`); foreground `#EAEAEA` (white phosphor) as the primary text color; the same red accent under the same rules. Terminal green `#4AF626` is optional: use it ONLY for a single specific UI element (one status indicator or one data readout), never as a general text color; if it serves no clear purpose, omit it entirely.
+
+## Layout and spatial engineering
+
+The layout must appear mathematically engineered; reject conventional web padding in favor of visible compartmentalization.
+
+- Blueprint grid: strict CSS Grid architecture. Elements do not float; anchor them precisely to grid tracks and intersections.
+- Visible compartmentalization: extensive solid borders (`1px` or `2px solid`) delineating distinct zones of information; horizontal rules frequently spanning the entire container width to segregate operational units.
+- Bimodal density: oscillate between extreme data density (tightly packed monospace metadata) and vast expanses of calculated negative space framing macro-typography.
+- Geometry: absolute rejection of `border-radius`. All corners exactly 90 degrees to enforce mechanical rigidity.
+
+## Components and symbology
+
+Replace standard web UI conventions with utilitarian, industrial graphic elements.
+
+- Syntax decoration: frame data points with ASCII — `[ DELIVERY SYSTEMS ]`, `< RE-IND >`; directional marks `>>>`, `///`, `\\\\`.
+- Industrial markers: registration `(R)`, copyright `(C)`, and trademark `(TM)` symbols used prominently as structural geometric elements, not legal text.
+- Technical assets: crosshairs (`+`) at grid intersections, repeating vertical barcode lines, thick horizontal warning stripes, and randomized string data (`REV 2.6`, `UNIT / D-01`) to simulate active mechanical processes.
+
+## Textural and post-processing effects
+
+Engineer simulated analog degradation into the frontend via CSS and SVG filters so the design never appears purely digital.
+
+- Halftone / 1-bit dithering: transform continuous-tone images or large serif typography into dot-matrix patterns via pre-processing or CSS `mix-blend-mode: multiply` overlays combined with SVG radial dot patterns.
+- CRT scanlines (terminal mode): apply `repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.1) 2px, rgba(0,0,0,0.1) 4px)` to the background to simulate horizontal electron beam sweeps.
+- Mechanical noise: one global, low-opacity SVG static/noise filter on the DOM root for unified physical grain across both dark and light modes.
+
+## Web engineering directives
+
+1. Grid determinism: use `display: grid; gap: 1px;` with contrasting parent/child background colors to generate mathematically perfect, razor-thin dividing lines without complex border declarations.
+2. Semantic rigidity: construct the DOM with precise semantic tags (`<data>`, `<samp>`, `<kbd>`, `<output>`, `<dl>`) to accurately reflect the technical nature of the telemetry.
+3. Typography clamping: implement CSS `clamp()` exclusively for macro-typography so massive text scales aggressively while maintaining structural integrity across viewports.

--- a/crates/services/assets/design_styles/taste-minimalist-editorial.md
+++ b/crates/services/assets/design_styles/taste-minimalist-editorial.md
@@ -1,0 +1,79 @@
+<!--
+Adapted from the "minimalist-ui" skill in Leonxlnx/taste-skill
+Source: https://github.com/Leonxlnx/taste-skill
+License: MIT. See the SoloDawn LICENSE file for full attribution.
+Changes: condensed and adapted for automated prompt injection (2026-07-04).
+-->
+
+# Premium Utilitarian Minimalism and Editorial UI
+
+Build highly refined, ultra-minimalist, document-style web interfaces analogous to top-tier workspace platforms. Enforce a high-contrast warm monochrome palette, a bespoke typographic hierarchy, meticulous structural macro-whitespace, bento-grid layouts, and an ultra-flat component architecture with deliberate muted pastel accents. Actively reject standard generic SaaS design trends.
+
+## Absolute negative constraints (banned elements)
+
+- DO NOT use the "Inter", "Roboto", or "Open Sans" typefaces.
+- DO NOT use generic thin-line icon libraries like "Lucide", "Feather", or standard "Heroicons".
+- DO NOT use Tailwind's default heavy drop shadows (`shadow-md`, `shadow-lg`, `shadow-xl`). Shadows must be practically non-existent or heavily customized to be ultra-diffuse and low opacity (< 0.05).
+- DO NOT use primary colored backgrounds for large elements or sections (no bright blue, green, or red hero sections).
+- DO NOT use gradients, neon colors, or 3D glassmorphism (beyond subtle navbar blurs).
+- DO NOT use `rounded-full` (pill shapes) for large containers, cards, or primary buttons.
+- DO NOT use emojis anywhere in code, markup, text content, headings, or alt text. Replace with proper icons or clean SVG primitives.
+- DO NOT use generic placeholder names like "John Doe", "Acme Corp", or "Lorem Ipsum". Use realistic, contextual content.
+- DO NOT use AI copywriting cliches: "Elevate", "Seamless", "Unleash", "Next-Gen", "Game-changer", "Delve". Write plain, specific language.
+
+## Typographic architecture
+
+Rely on extreme typographic contrast and premium font selection to establish an editorial feel.
+
+- Primary sans-serif (body, UI, buttons): `font-family: 'SF Pro Display', 'Geist Sans', 'Helvetica Neue', 'Switzer', sans-serif`.
+- Editorial serif (hero headings and quotes): `font-family: 'Lyon Text', 'Newsreader', 'Playfair Display', 'Instrument Serif', serif`, with tight tracking (`letter-spacing: -0.02em` to `-0.04em`) and tight line-height (`1.1`).
+- Monospace (code, keystrokes, metadata): `font-family: 'Geist Mono', 'SF Mono', 'JetBrains Mono', monospace`.
+- Body text must never be absolute black (`#000000`). Use off-black/charcoal (`#111111` or `#2F3437`) with a generous `line-height` of `1.6`. Secondary text: muted gray `#787774`.
+
+## Color palette (warm monochrome plus spot pastels)
+
+Treat color as a scarce resource, used only for semantic meaning or subtle accents.
+
+- Canvas / background: pure white `#FFFFFF` or warm bone/off-white `#F7F6F3` / `#FBFBFA`.
+- Primary surface (cards): `#FFFFFF` or `#F9F9F8`.
+- Structural borders / dividers: ultra-light gray `#EAEAEA` or `rgba(0,0,0,0.06)`.
+- Accents: exclusively highly desaturated, washed-out pastels for tags, inline code backgrounds, or subtle icon backgrounds:
+  - Pale red `#FDEBEC` (text `#9F2F2D`)
+  - Pale blue `#E1F3FE` (text `#1F6C9F`)
+  - Pale green `#EDF3EC` (text `#346538`)
+  - Pale yellow `#FBF3DB` (text `#956400`)
+
+## Component specifications
+
+- Bento feature grids: asymmetrical CSS Grid layouts. Cards must have exactly `border: 1px solid #EAEAEA`, crisp border-radius (`8px` or `12px` maximum), and generous internal padding (`24px` to `40px`).
+- Primary CTA buttons: solid background `#111111`, text `#FFFFFF`, slight border-radius (`4px` to `6px`), no box-shadow. Hover: a subtle shift to `#333333` or a micro-scale `transform: scale(0.98)`.
+- Tags and status badges: pill-shaped (`border-radius: 9999px`), very small typography (`text-xs`), uppercase with wide tracking (`letter-spacing: 0.05em`), backgrounds drawn from the muted pastels above.
+- Accordions (FAQ): strip all container boxes; separate items only with `border-bottom: 1px solid #EAEAEA`; use clean, sharp `+` and `-` icons for the toggle state.
+- Keystroke micro-UIs: render shortcuts as physical keys using `<kbd>` tags: `border: 1px solid #EAEAEA`, `border-radius: 4px`, `background: #F7F6F3`, monospace font.
+- Faux-OS window chrome: when mocking up software, wrap it in a minimalist container with a white top bar containing three small, light gray circles (macOS-style window controls).
+
+## Iconography and imagery
+
+- System icons: Phosphor Icons (Bold or Fill weights) or Radix UI Icons for a technical, slightly thicker-stroke aesthetic. Standardize stroke width across all icons.
+- Illustrations: monochromatic, rough continuous-line ink sketches on a white background, featuring a single offset geometric shape filled with a muted pastel.
+- Photography: high-quality, desaturated images with a warm tone; apply subtle overlays (`opacity: 0.04` warm grain) to blend photos into the monochrome palette. Never use oversaturated stock photos. Use `https://picsum.photos/seed/{context}/1200/800` placeholders when real assets are unavailable.
+- Hero and section backgrounds: sections must not feel empty and flat. Use subtle full-width imagery at very low opacity, soft radial light spots (warm `radial-gradient` at `opacity: 0.03`), or minimal geometric line patterns for depth without breaking the clean aesthetic.
+
+## Subtle motion and micro-animations
+
+Motion should feel invisible — present but never distracting. The goal is quiet sophistication, not spectacle.
+
+- Scroll entry: elements fade in gently as they enter the viewport — `translateY(12px)` + `opacity: 0` resolving over `600ms` with `cubic-bezier(0.16, 1, 0.3, 1)`. Use `IntersectionObserver`, never `window.addEventListener('scroll')`.
+- Hover: cards lift with an ultra-subtle shadow shift (`box-shadow` from `0 0 0` to `0 2px 8px rgba(0,0,0,0.04)` over `200ms`); buttons respond with `scale(0.98)` on `:active`.
+- Staggered reveals: lists and grid items enter with a cascade delay (`animation-delay: calc(var(--index) * 80ms)`). Never mount everything at once.
+- Ambient background motion (optional): a single, very slow radial gradient blob (`animation-duration: 20s+`, `opacity: 0.02-0.04`) drifting behind hero sections, applied only to a `position: fixed; pointer-events: none` layer. Never on scrolling containers.
+- Performance: animate exclusively via `transform` and `opacity`; no layout-triggering properties (`top`, `left`, `width`, `height`). Use `will-change: transform` sparingly and only on actively animating elements.
+
+## Execution order
+
+1. Establish the macro-whitespace first: massive vertical padding between sections (`py-24` or `py-32`).
+2. Constrain the main typographic content width to `max-w-4xl` or `max-w-5xl`.
+3. Apply the custom typographic hierarchy and monochrome color variables immediately.
+4. Ensure every card, divider, and border adheres strictly to the `1px solid #EAEAEA` rule.
+5. Add scroll-entry animations to all major content blocks.
+6. Give sections visual depth through imagery, ambient gradients, or subtle textures — no empty flat backgrounds.

--- a/crates/services/assets/design_styles/taste-soft-premium.md
+++ b/crates/services/assets/design_styles/taste-soft-premium.md
@@ -1,0 +1,62 @@
+<!--
+Adapted from the "soft-skill" skill in Leonxlnx/taste-skill
+Source: https://github.com/Leonxlnx/taste-skill
+License: MIT. See the SoloDawn LICENSE file for full attribution.
+Changes: condensed and adapted for automated prompt injection (2026-07-04).
+-->
+
+# Soft Premium UI and Motion Choreography
+
+Engineer agency-level digital experiences worth a $150k build, not just websites. The output must exude haptic depth, cinematic spatial rhythm, obsessive micro-interactions, and flawless fluid motion in the elite Apple-esque / Linear-tier design language. Never generate the exact same layout or aesthetic twice in a row: dynamically combine premium layout archetypes and texture profiles per project.
+
+## Strict anti-patterns — the design instantly fails if any appear
+
+- Banned fonts: Inter, Roboto, Arial, Open Sans, Helvetica. Assume premium faces like `Geist`, `Clash Display`, `PP Editorial New`, or `Plus Jakarta Sans` are available.
+- Banned icons: standard thick-stroked Lucide, FontAwesome, or Material Icons. Use only ultra-light, precise lines (Phosphor Light, Remix Line).
+- Banned borders/shadows: generic 1px solid gray borders; harsh dark drop shadows (`shadow-md`, `rgba(0,0,0,0.3)`).
+- Banned layouts: edge-to-edge sticky navbars glued to the top; symmetrical, boring 3-column Bootstrap-style grids without massive whitespace gaps.
+- Banned motion: standard `linear` or `ease-in-out` transitions; instant state changes without interpolation.
+
+## Creative variance — pick ONE vibe and ONE layout archetype per project
+
+Vibe and texture:
+1. Ethereal Glass (SaaS / AI / tech): deepest OLED black (`#050505`); radial mesh gradients (subtle glowing purple/emerald orbs) in the background; vantablack cards with heavy `backdrop-blur-2xl` and pure white/10 hairlines; wide geometric grotesk typography.
+2. Editorial Luxury (lifestyle / real estate / agency): warm creams (`#FDFBF7`), muted sage, or deep espresso tones; high-contrast variable serif for massive headings; subtle CSS noise/film-grain overlay (`opacity-[0.03]`) for a physical paper feel.
+3. Soft Structuralism (consumer / health / portfolio): silver-grey or completely white backgrounds; massive bold grotesk typography; airy, floating components with unbelievably soft, highly diffused ambient shadows.
+
+Layout:
+1. Asymmetrical Bento: masonry-like CSS Grid of varying card sizes (`col-span-8 row-span-2` next to stacked `col-span-4`). Mobile: single-column stack (`grid-cols-1`, `gap-6`); all `col-span` overrides reset to `col-span-1`.
+2. Z-Axis Cascade: elements stacked like physical cards, slightly overlapping at varying depths, some rotated `-2deg` or `3deg`. Below `768px`: remove all rotations and negative-margin overlaps and stack vertically — overlaps cause touch-target conflicts.
+3. Editorial Split: massive typography on the left half (`w-1/2`); interactive, scrollable horizontal image pills or staggered cards on the right. Mobile: full-width vertical stack, typography on top, horizontal scroll preserved where needed.
+
+Universal mobile override: below `768px`, every asymmetric layout aggressively falls back to `w-full`, `px-4`, `py-8`. Never use `h-screen` for full-height sections — always `min-h-[100dvh]` to prevent iOS Safari viewport jumping.
+
+## Haptic micro-aesthetics
+
+- The Double-Bezel (nested architecture): never place a premium card, image, or container flat on the background; it must read like machined hardware (a glass plate sitting in an aluminum tray). Outer shell: subtle background (`bg-black/5` or `bg-white/5`), hairline border (`ring-1 ring-black/5` or `border border-white/10`), padding `p-1.5` or `p-2`, large radius (`rounded-[2rem]`). Inner core: its own distinct background, an inner highlight (`shadow-[inset_0_1px_1px_rgba(255,255,255,0.15)]`), and a mathematically smaller radius (`rounded-[calc(2rem-0.375rem)]`) for concentric curves.
+- Nested CTA ("island" buttons): primary buttons are fully rounded pills (`rounded-full`, `px-6 py-3`). A trailing arrow never sits naked next to the text — nest it inside its own circular wrapper (`w-8 h-8 rounded-full bg-black/5 dark:bg-white/10 flex items-center justify-center`) flush with the button's right inner padding.
+- Spatial rhythm: double your standard padding — `py-24` to `py-40` per section; let the design breathe heavily. Precede major H1/H2s with a microscopic pill eyebrow (`rounded-full px-3 py-1 text-[10px] uppercase tracking-[0.2em] font-medium`).
+
+## Motion choreography
+
+All motion must simulate real-world mass and spring physics via custom cubic-beziers (e.g. `transition-all duration-700 ease-[cubic-bezier(0.32,0.72,0,1)]`).
+
+- Fluid island nav: the navbar floats as a detached glass pill (`mt-6`, `mx-auto`, `w-max`, `rounded-full`). On click, the hamburger lines fluidly rotate and translate into a perfect X (`rotate-45` / `-rotate-45` with absolute positioning) — never just disappear. The menu opens as a massive screen-filling overlay with heavy glass (`backdrop-blur-3xl bg-black/80` or `bg-white/80`); links fade in and slide up (`translate-y-12 opacity-0` to `translate-y-0 opacity-100`) with staggered delays (`delay-100`, `delay-150`, `delay-200`).
+- Magnetic button physics: on hover, never just change the background color. Scale the button down on press (`active:scale-[0.98]`); translate the nested icon circle diagonally (`group-hover:translate-x-1 group-hover:-translate-y-[1px]`) and scale it up slightly (`scale-105`) for internal kinetic tension.
+- Scroll interpolation: elements never appear statically. As they enter the viewport, execute a gentle, heavy fade-up (`translate-y-16 blur-md opacity-0` resolving to `translate-y-0 blur-0 opacity-100` over 800ms+). Use `IntersectionObserver` or Framer Motion `whileInView`; never `window.addEventListener('scroll')`.
+
+## Performance guardrails
+
+- Animate exclusively via `transform` and `opacity`; never `top`, `left`, `width`, or `height`. Use `will-change: transform` sparingly, only on actively animating elements.
+- Apply `backdrop-blur` only to fixed or sticky elements (navbars, overlays); never to scrolling containers or large content areas.
+- Grain/noise overlays only on fixed, `pointer-events-none` pseudo-elements (`position: fixed; inset: 0`); never on scrolling containers.
+- Z-index discipline: no arbitrary `z-50` or `z-[9999]`; reserve z-indexes strictly for systemic layers (sticky nav, modals, overlays, tooltips).
+
+## Pre-delivery checklist
+
+- No banned fonts, icons, borders, shadows, layouts, or motion patterns are present.
+- A vibe archetype and a layout archetype were consciously selected and applied.
+- All major cards and containers use the Double-Bezel nested architecture; CTAs use the button-in-button pattern where applicable.
+- Section padding is at minimum `py-24`; all transitions use custom cubic-bezier curves; scroll entry animations are present.
+- The layout collapses gracefully below `768px` to single-column `w-full px-4`; animations use only `transform`/`opacity`; `backdrop-blur` only on fixed/sticky elements.
+- The overall impression reads as an agency build, not a template with nice fonts.

--- a/crates/services/src/services/architecture_knowledge.rs
+++ b/crates/services/src/services/architecture_knowledge.rs
@@ -1,0 +1,687 @@
+//! Architecture knowledge base.
+//!
+//! Syncs architecture guidance from configurable GitHub repos (builtin:
+//! study8677/awesome-architecture, MIT) into `architecture_entry` rows and
+//! builds the "Architecture Guidance" prompt section injected into workflow
+//! goals at materialization: a self-answered methodology checklist (adapted
+//! from study8677/architecture-copilot, MIT) plus digests of the reference
+//! templates that best match the requirement text.
+//!
+//! Every operation here is fail-open: sync errors are recorded on the source
+//! row and planning proceeds without guidance rather than blocking.
+
+use db::models::architecture_entry::ArchitectureEntry;
+use db::models::architecture_source::ArchitectureSource;
+use db::models::system_settings::SystemSetting;
+use serde::Deserialize;
+use sqlx::SqlitePool;
+use std::time::Duration;
+
+/// Builtin knowledge source coordinates.
+const BUILTIN_OWNER: &str = "study8677";
+const BUILTIN_REPO: &str = "awesome-architecture";
+const BUILTIN_BRANCH: &str = "main";
+const BUILTIN_NAME: &str = "Awesome Architecture";
+
+/// system_settings key: "true"/"1" (or missing) enables guidance injection.
+pub const SETTING_GUIDANCE_ENABLED: &str = "architecture_guidance_enabled";
+
+/// Methodology checklist vendored from architecture-copilot (see LICENSE).
+const METHODOLOGY: &str = include_str!("../../assets/architecture/methodology.md");
+
+/// Skip upstream files larger than this (defensive; templates are ~30 KB).
+const MAX_FILE_BYTES: u64 = 512 * 1024;
+/// Cap for each injected template digest, in bytes (UTF-8 safe).
+const DIGEST_MAX_BYTES: usize = 3000;
+/// How many matched templates to inject.
+const MAX_MATCHES: usize = 2;
+/// Minimum match score before a template is considered relevant.
+const MIN_MATCH_SCORE: u32 = 3;
+/// Background loop: check every 6 h, re-sync sources older than 24 h.
+const BACKGROUND_CHECK_SECS: u64 = 6 * 60 * 60;
+const STALE_AFTER_SECS: i64 = 24 * 60 * 60;
+/// Delay before the first background sync so server startup stays snappy.
+const STARTUP_DELAY_SECS: u64 = 20;
+
+#[derive(Debug, Deserialize)]
+struct GitTreeResponse {
+    sha: String,
+    #[serde(default)]
+    truncated: bool,
+    #[serde(default)]
+    tree: Vec<GitTreeNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitTreeNode {
+    path: String,
+    #[serde(rename = "type")]
+    node_type: String,
+    sha: String,
+    #[serde(default)]
+    size: Option<u64>,
+}
+
+/// Result of one source sync.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncOutcome {
+    pub source_id: String,
+    pub tree_sha: String,
+    /// True when the tree sha matched the previous sync and nothing was fetched.
+    pub unchanged: bool,
+    pub fetched: u32,
+    pub removed: u64,
+    pub total_entries: i64,
+}
+
+/// Ensure the builtin knowledge source row exists (idempotent).
+pub async fn ensure_builtin_source(pool: &SqlitePool) -> anyhow::Result<()> {
+    if ArchitectureSource::find_by_coords(pool, BUILTIN_OWNER, BUILTIN_REPO, BUILTIN_BRANCH)
+        .await?
+        .is_some()
+    {
+        return Ok(());
+    }
+    let mut source = ArchitectureSource::new(
+        BUILTIN_NAME,
+        BUILTIN_OWNER,
+        BUILTIN_REPO,
+        BUILTIN_BRANCH,
+        &["templates/"],
+    );
+    source.builtin = true;
+    ArchitectureSource::insert(pool, &source).await?;
+    tracing::info!(source_id = %source.id, "Seeded builtin architecture knowledge source");
+    Ok(())
+}
+
+/// Whether guidance injection is enabled. Defaults to true when the setting
+/// row is absent (feature ships on; users opt out in settings).
+pub async fn guidance_enabled(pool: &SqlitePool) -> bool {
+    match SystemSetting::get(pool, SETTING_GUIDANCE_ENABLED).await {
+        Ok(Some(v)) => v.trim().eq_ignore_ascii_case("true") || v.trim() == "1",
+        Ok(None) => true,
+        Err(e) => {
+            tracing::warn!("Failed to read {SETTING_GUIDANCE_ENABLED}: {e}");
+            true
+        }
+    }
+}
+
+fn http_client() -> anyhow::Result<reqwest::Client> {
+    Ok(reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent("SoloDawn-architecture-sync")
+        .build()?)
+}
+
+/// Optional GitHub token for higher API rate limits.
+fn github_token() -> Option<String> {
+    std::env::var("SOLODAWN_GITHUB_TOKEN")
+        .or_else(|_| std::env::var("GITHUB_TOKEN"))
+        .ok()
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+}
+
+/// Sync one source: list the git tree, fetch changed markdown files, upsert
+/// entries, drop entries whose upstream files vanished.
+pub async fn sync_source(
+    pool: &SqlitePool,
+    source: &ArchitectureSource,
+) -> anyhow::Result<SyncOutcome> {
+    let client = http_client()?;
+
+    let tree_url = format!(
+        "https://api.github.com/repos/{}/{}/git/trees/{}?recursive=1",
+        source.owner, source.repo, source.branch
+    );
+    let mut req = client
+        .get(&tree_url)
+        .header("Accept", "application/vnd.github+json");
+    if let Some(token) = github_token() {
+        req = req.bearer_auth(token);
+    }
+    let resp = req.send().await?;
+    if !resp.status().is_success() {
+        anyhow::bail!("GitHub tree request failed: HTTP {}", resp.status());
+    }
+    let tree: GitTreeResponse = resp.json().await?;
+    if tree.truncated {
+        tracing::warn!(
+            source_id = %source.id,
+            "GitHub tree response truncated; sync covers only the listed files"
+        );
+    }
+
+    let include_paths = source.include_path_list();
+    let wanted: Vec<&GitTreeNode> = tree
+        .tree
+        .iter()
+        .filter(|n| n.node_type == "blob")
+        .filter(|n| is_wanted_path(&n.path, &include_paths))
+        .filter(|n| n.size.unwrap_or(0) <= MAX_FILE_BYTES)
+        .collect();
+    let keep_paths: Vec<String> = wanted.iter().map(|n| n.path.clone()).collect();
+
+    if source.last_tree_sha.as_deref() == Some(tree.sha.as_str()) {
+        let total = ArchitectureEntry::count_by_source(pool, &source.id).await?;
+        ArchitectureSource::record_sync(pool, &source.id, Some(&tree.sha), "ok").await?;
+        return Ok(SyncOutcome {
+            source_id: source.id.clone(),
+            tree_sha: tree.sha,
+            unchanged: true,
+            fetched: 0,
+            removed: 0,
+            total_entries: total,
+        });
+    }
+
+    let existing = ArchitectureEntry::sha_index(pool, &source.id).await?;
+    let mut fetched: u32 = 0;
+    for node in &wanted {
+        let unchanged = existing
+            .iter()
+            .any(|(path, sha)| path == &node.path && sha == &node.sha);
+        if unchanged {
+            continue;
+        }
+        let raw_url = format!(
+            "https://raw.githubusercontent.com/{}/{}/{}/{}",
+            source.owner, source.repo, source.branch, node.path
+        );
+        let content = match client.get(&raw_url).send().await {
+            Ok(r) if r.status().is_success() => match r.text().await {
+                Ok(t) => t,
+                Err(e) => {
+                    tracing::warn!(path = %node.path, "Failed to read file body: {e}");
+                    continue;
+                }
+            },
+            Ok(r) => {
+                tracing::warn!(path = %node.path, status = %r.status(), "Raw fetch failed");
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(path = %node.path, "Raw fetch failed: {e}");
+                continue;
+            }
+        };
+        let parsed = parse_entry(&node.path, &content);
+        let entry = ArchitectureEntry::new(
+            &source.id,
+            &node.path,
+            &parsed.category,
+            &parsed.slug,
+            &parsed.title,
+            &parsed.keywords,
+            &parsed.digest,
+            &content,
+            &node.sha,
+        );
+        ArchitectureEntry::upsert(pool, &entry).await?;
+        fetched += 1;
+    }
+
+    let removed = ArchitectureEntry::delete_missing(pool, &source.id, &keep_paths).await?;
+    let total = ArchitectureEntry::count_by_source(pool, &source.id).await?;
+    ArchitectureSource::record_sync(pool, &source.id, Some(&tree.sha), "ok").await?;
+    tracing::info!(
+        source_id = %source.id,
+        fetched,
+        removed,
+        total,
+        "Architecture knowledge sync complete"
+    );
+    Ok(SyncOutcome {
+        source_id: source.id.clone(),
+        tree_sha: tree.sha,
+        unchanged: false,
+        fetched,
+        removed,
+        total_entries: total,
+    })
+}
+
+/// Sync wrapper that records failures on the source row instead of bubbling.
+pub async fn sync_source_recorded(pool: &SqlitePool, source: &ArchitectureSource) -> Option<SyncOutcome> {
+    match sync_source(pool, source).await {
+        Ok(outcome) => Some(outcome),
+        Err(e) => {
+            tracing::warn!(source_id = %source.id, "Architecture sync failed: {e}");
+            let status = format!("error: {e}");
+            let status = status.get(..status.floor_char_boundary(300)).unwrap_or(&status);
+            if let Err(record_err) =
+                ArchitectureSource::record_sync(pool, &source.id, None, status).await
+            {
+                tracing::warn!(source_id = %source.id, "Failed to record sync error: {record_err}");
+            }
+            None
+        }
+    }
+}
+
+/// Spawn the background sync loop: after a short startup delay, re-sync any
+/// enabled source that has not synced successfully in the last 24 h, then
+/// re-check every 6 h.
+pub fn spawn_background_sync(pool: SqlitePool) {
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(STARTUP_DELAY_SECS)).await;
+        loop {
+            match ArchitectureSource::find_enabled(&pool).await {
+                Ok(sources) => {
+                    for source in sources {
+                        let stale = source
+                            .last_synced_at
+                            .map(|t| (chrono::Utc::now() - t).num_seconds() >= STALE_AFTER_SECS)
+                            .unwrap_or(true);
+                        let last_ok = source.last_sync_status.as_deref() == Some("ok");
+                        if stale || !last_ok {
+                            sync_source_recorded(&pool, &source).await;
+                        }
+                    }
+                }
+                Err(e) => tracing::warn!("Failed to list architecture sources: {e}"),
+            }
+            tokio::time::sleep(Duration::from_secs(BACKGROUND_CHECK_SECS)).await;
+        }
+    });
+}
+
+/// Build the "Architecture Guidance" section for a workflow goal, or `None`
+/// when disabled. Matching failures degrade to methodology-only guidance.
+pub async fn build_architecture_context(
+    pool: &SqlitePool,
+    requirement_text: &str,
+) -> Option<String> {
+    if !guidance_enabled(pool).await {
+        return None;
+    }
+
+    let mut section = String::from("## Architecture Guidance\n\n");
+    section.push_str(strip_attribution_header(METHODOLOGY).trim());
+    section.push('\n');
+
+    if requirement_text.trim().len() >= 10 {
+        match ArchitectureEntry::find_matchable(pool).await {
+            Ok(entries) => {
+                for entry in top_matches(&entries, requirement_text) {
+                    section.push_str(&format!(
+                        "\n### Reference architecture: {} ({})\n\
+                         Condensed from the matched architecture template — treat these as the \
+                         decision forks and failure modes this kind of system must resolve:\n\n",
+                        entry.title, entry.slug
+                    ));
+                    section.push_str(cap_str(&entry.digest, DIGEST_MAX_BYTES));
+                    section.push('\n');
+                }
+            }
+            Err(e) => tracing::warn!("Architecture entry matching failed: {e}"),
+        }
+    }
+
+    Some(section)
+}
+
+/// Score all entries against the requirement text and return the winners.
+fn top_matches<'a>(
+    entries: &'a [ArchitectureEntry],
+    requirement_text: &str,
+) -> Vec<&'a ArchitectureEntry> {
+    let haystack = requirement_text.to_lowercase();
+    let mut scored: Vec<(u32, &ArchitectureEntry)> = entries
+        .iter()
+        .filter(|e| !e.digest.trim().is_empty())
+        .map(|e| (match_score(e, &haystack), e))
+        .filter(|(score, _)| *score >= MIN_MATCH_SCORE)
+        .collect();
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.slug.cmp(&b.1.slug)));
+    scored.into_iter().take(MAX_MATCHES).map(|(_, e)| e).collect()
+}
+
+/// Deterministic keyword-overlap score. `haystack` must be lowercased.
+fn match_score(entry: &ArchitectureEntry, haystack: &str) -> u32 {
+    let mut score = 0u32;
+    // Slug tokens ("realtime", "chat") hit English requirements.
+    for token in entry.slug.split(['-', '_']) {
+        if token.len() >= 3 && haystack.contains(&token.to_lowercase()) {
+            score += 3;
+        }
+    }
+    // The (usually Chinese) title hits zh requirements.
+    let title = entry.title.trim().to_lowercase();
+    if title.len() >= 2 && haystack.contains(&title) {
+        score += 4;
+    }
+    // Product/tech names ("slack", "stripe") are the most distinctive
+    // signal a requirement can carry, so one hit alone clears MIN_MATCH_SCORE.
+    for keyword in entry.keyword_list() {
+        let kw = keyword.trim().to_lowercase();
+        if kw.len() >= 2 && haystack.contains(&kw) {
+            score += 3;
+        }
+    }
+    score
+}
+
+struct ParsedEntry {
+    category: String,
+    slug: String,
+    title: String,
+    keywords: Vec<String>,
+    digest: String,
+}
+
+/// Whether a tree path should be synced: inside an include prefix, markdown,
+/// not an underscore-prefixed spec file, and not the include root's own index.
+fn is_wanted_path(path: &str, include_paths: &[String]) -> bool {
+    if !path.to_lowercase().ends_with(".md") {
+        return false;
+    }
+    let basename = path.rsplit('/').next().unwrap_or(path);
+    if basename.starts_with('_') {
+        return false;
+    }
+    include_paths.iter().any(|prefix| {
+        let prefix = prefix.trim_start_matches('/');
+        let prefix = prefix.trim_end_matches('/');
+        if prefix.is_empty() {
+            return false;
+        }
+        // "<prefix>/README.md" is the human index of the directory, skip it.
+        path.strip_prefix(&format!("{prefix}/"))
+            .is_some_and(|rest| rest != "README.md")
+    })
+}
+
+fn parse_entry(path: &str, content: &str) -> ParsedEntry {
+    let category = derive_category(path);
+    let slug = derive_slug(path);
+    let title = extract_title(content).unwrap_or_else(|| slug.clone());
+    let keywords = extract_keywords(&slug, &title, content);
+    let digest = extract_digest(content);
+    ParsedEntry {
+        category,
+        slug,
+        title,
+        keywords,
+        digest,
+    }
+}
+
+fn derive_category(path: &str) -> String {
+    let lowered = path.to_lowercase();
+    if lowered.contains("template") {
+        "template".to_string()
+    } else if lowered.contains("tutorial") {
+        "tutorial".to_string()
+    } else if lowered.contains("case") {
+        "case".to_string()
+    } else {
+        "other".to_string()
+    }
+}
+
+/// `templates/realtime-chat/README.md` → `realtime-chat`; `tutorial/01-intro.md` → `01-intro`.
+fn derive_slug(path: &str) -> String {
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    match segments.as_slice() {
+        [.., dir, file] if file.eq_ignore_ascii_case("readme.md") => (*dir).to_string(),
+        [.., file] => file.trim_end_matches(".md").trim_end_matches(".MD").to_string(),
+        [] => path.to_string(),
+    }
+}
+
+fn extract_title(content: &str) -> Option<String> {
+    content.lines().find_map(|line| {
+        let trimmed = line.trim();
+        trimmed.strip_prefix("# ").map(|t| {
+            t.trim()
+                .trim_start_matches(|c: char| !c.is_alphanumeric() && !is_cjk(c))
+                .trim()
+                .to_string()
+        })
+    })
+}
+
+fn is_cjk(c: char) -> bool {
+    matches!(c, '\u{4E00}'..='\u{9FFF}' | '\u{3400}'..='\u{4DBF}')
+}
+
+/// Keywords for requirement matching: slug tokens plus Latin product/tech
+/// names appearing near the top of the document (e.g. "WhatsApp", "Slack").
+fn extract_keywords(slug: &str, title: &str, content: &str) -> Vec<String> {
+    let mut keywords: Vec<String> = Vec::new();
+    fn push(keywords: &mut Vec<String>, kw: String) {
+        let kw = kw.trim().to_string();
+        if kw.len() >= 2 && !keywords.iter().any(|k| k.eq_ignore_ascii_case(&kw)) {
+            keywords.push(kw);
+        }
+    }
+
+    for token in slug.split(['-', '_']) {
+        if token.len() >= 3 {
+            push(&mut keywords, token.to_lowercase());
+        }
+    }
+    push(&mut keywords, title.to_string());
+
+    // Latin names near the top of the doc: product references like
+    // "WhatsApp、Slack、微信" or "Stripe / PayPal".
+    let head_end = content.floor_char_boundary(800.min(content.len()));
+    let head = &content[..head_end];
+    for candidate in head.split(|c: char| !c.is_ascii_alphanumeric() && c != '.') {
+        let word = candidate.trim_matches('.');
+        if (4..=20).contains(&word.len())
+            && word.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+            && word.chars().all(|c| c.is_ascii_alphanumeric() || c == '.')
+        {
+            push(&mut keywords, word.to_lowercase());
+        }
+        if keywords.len() >= 16 {
+            break;
+        }
+    }
+    keywords.truncate(16);
+    keywords
+}
+
+/// Heading keywords that mark the highest-value sections of a template
+/// (key decisions & trade-offs, scaling & bottlenecks, anti-patterns).
+const DIGEST_HEADING_KEYWORDS: [&str; 12] = [
+    "关键决策",
+    "权衡",
+    "规模化",
+    "瓶颈",
+    "误区",
+    "反模式",
+    "key decision",
+    "trade-off",
+    "tradeoff",
+    "scal",
+    "bottleneck",
+    "anti-pattern",
+];
+
+/// Extract the digest: the sections whose headings match
+/// [`DIGEST_HEADING_KEYWORDS`], else the document head as fallback.
+fn extract_digest(content: &str) -> String {
+    let mut digest = String::new();
+    let mut capturing = false;
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        let heading_level = trimmed.chars().take_while(|c| *c == '#').count();
+        if (2..=3).contains(&heading_level) {
+            let lowered = trimmed.to_lowercase();
+            capturing = DIGEST_HEADING_KEYWORDS.iter().any(|kw| lowered.contains(kw));
+            if capturing {
+                digest.push_str(trimmed);
+                digest.push('\n');
+            }
+            continue;
+        }
+        if heading_level == 1 {
+            capturing = false;
+            continue;
+        }
+        if capturing {
+            digest.push_str(line);
+            digest.push('\n');
+        }
+        if digest.len() > DIGEST_MAX_BYTES * 2 {
+            break;
+        }
+    }
+
+    if digest.trim().is_empty() {
+        // Fallback: skip the title line, take the document head.
+        let body: String = content
+            .lines()
+            .skip_while(|l| l.trim().is_empty() || l.trim_start().starts_with('#'))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return cap_str(&body, 1500).trim().to_string();
+    }
+    cap_str(&digest, DIGEST_MAX_BYTES).trim().to_string()
+}
+
+/// Byte-cap a string on a valid UTF-8 boundary.
+fn cap_str(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        s
+    } else {
+        &s[..s.floor_char_boundary(max_bytes)]
+    }
+}
+
+/// Strip the leading `<!-- ... -->` attribution comment from a vendored asset
+/// so prompt payloads stay clean; the attribution lives in the file + LICENSE.
+pub(crate) fn strip_attribution_header(content: &str) -> &str {
+    let trimmed = content.trim_start();
+    if let Some(rest) = trimmed.strip_prefix("<!--") {
+        if let Some(end) = rest.find("-->") {
+            return rest[end + 3..].trim_start();
+        }
+    }
+    content
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry_with(slug: &str, title: &str, keywords: &[&str], digest: &str) -> ArchitectureEntry {
+        ArchitectureEntry::new(
+            "src-1",
+            &format!("templates/{slug}/README.md"),
+            "template",
+            slug,
+            title,
+            &keywords.iter().map(|s| (*s).to_string()).collect::<Vec<_>>(),
+            digest,
+            "full content",
+            "sha-1",
+        )
+    }
+
+    #[test]
+    fn wanted_path_filters_indexes_and_specs() {
+        let includes = vec!["templates/".to_string()];
+        assert!(is_wanted_path("templates/realtime-chat/README.md", &includes));
+        assert!(is_wanted_path("templates/nested/deep/notes.md", &includes));
+        assert!(!is_wanted_path("templates/README.md", &includes), "include-root index skipped");
+        assert!(!is_wanted_path("templates/_TEMPLATE.md", &includes), "underscore spec skipped");
+        assert!(!is_wanted_path("tutorial/01-intro.md", &includes), "outside include");
+        assert!(!is_wanted_path("templates/realtime-chat/diagram.png", &includes));
+    }
+
+    #[test]
+    fn slug_and_category_derivation() {
+        assert_eq!(derive_slug("templates/realtime-chat/README.md"), "realtime-chat");
+        assert_eq!(derive_slug("tutorial/01-intro.md"), "01-intro");
+        assert_eq!(derive_category("templates/x/README.md"), "template");
+        assert_eq!(derive_category("tutorial/01.md"), "tutorial");
+        assert_eq!(derive_category("cases/saas/README.md"), "case");
+        assert_eq!(derive_category("en/random.md"), "other");
+    }
+
+    #[test]
+    fn title_extraction_strips_decorations() {
+        assert_eq!(
+            extract_title("# 🗺️ 实时通讯\n\nbody").as_deref(),
+            Some("实时通讯")
+        );
+        assert_eq!(extract_title("no heading here"), None);
+    }
+
+    #[test]
+    fn digest_prefers_key_sections() {
+        let content = "# 实时通讯\n\nintro text\n\n## 架构全景图\nboxes\n\n## 关键决策与权衡\n长连接怎么扩展\n\n## 规模化与瓶颈\n群扩散\n\n## 参考\nlinks\n";
+        let digest = extract_digest(content);
+        assert!(digest.contains("关键决策与权衡"));
+        assert!(digest.contains("规模化与瓶颈"));
+        assert!(!digest.contains("架构全景图"));
+        assert!(!digest.contains("links"));
+    }
+
+    #[test]
+    fn digest_falls_back_to_head() {
+        let content = "# Title\n\nplain body without key sections\nmore body\n";
+        let digest = extract_digest(content);
+        assert!(digest.contains("plain body"));
+    }
+
+    #[test]
+    fn keywords_pick_up_product_names() {
+        let content = "# 实时通讯\n\n> 代表产品:WhatsApp、Slack、微信\n\nbody";
+        let keywords = extract_keywords("realtime-chat", "实时通讯", content);
+        assert!(keywords.contains(&"realtime".to_string()));
+        assert!(keywords.contains(&"chat".to_string()));
+        assert!(keywords.contains(&"whatsapp".to_string()));
+        assert!(keywords.contains(&"slack".to_string()));
+    }
+
+    #[test]
+    fn matching_ranks_relevant_templates() {
+        let chat = entry_with(
+            "realtime-chat",
+            "实时通讯",
+            &["whatsapp", "slack", "实时通讯"],
+            "## 关键决策\n长连接",
+        );
+        let pay = entry_with(
+            "payment-system",
+            "支付系统",
+            &["stripe", "支付"],
+            "## 关键决策\n幂等",
+        );
+        let entries = vec![chat, pay];
+
+        let zh = top_matches(&entries, &"我想做一个类似 Slack 的团队实时聊天工具".to_lowercase());
+        assert_eq!(zh.len(), 1);
+        assert_eq!(zh[0].slug, "realtime-chat");
+
+        let en = top_matches(&entries, &"Build a payment system with Stripe integration".to_lowercase());
+        assert_eq!(en.len(), 1);
+        assert_eq!(en[0].slug, "payment-system");
+
+        let none = top_matches(&entries, &"写一个命令行贪吃蛇小游戏".to_lowercase());
+        assert!(none.is_empty());
+    }
+
+    #[test]
+    fn attribution_header_is_stripped() {
+        let content = "<!--\nAdapted from X\n-->\n\n# Checklist\nbody";
+        assert!(strip_attribution_header(content).starts_with("# Checklist"));
+        assert_eq!(strip_attribution_header("# No header"), "# No header");
+    }
+
+    #[test]
+    fn cap_str_respects_char_boundaries() {
+        let s = "中文字符串测试";
+        let capped = cap_str(s, 7);
+        assert!(capped.len() <= 7);
+        assert!(s.starts_with(capped));
+    }
+}

--- a/crates/services/src/services/design_direction.rs
+++ b/crates/services/src/services/design_direction.rs
@@ -1,0 +1,258 @@
+//! Design direction: resolves the design style selected for a planning round
+//! and renders the "Design Direction" prompt section injected into the
+//! workflow goal. Builtin presets are vendored adaptations of high-star
+//! open-source design skills (see LICENSE) seeded at startup; users manage
+//! additional styles through the design-styles API.
+
+use db::models::design_style::DesignStyle;
+use db::models::system_settings::SystemSetting;
+use sqlx::SqlitePool;
+
+/// system_settings key holding the fallback style slug ("" = none).
+pub const SETTING_DEFAULT_STYLE: &str = "default_design_style";
+
+/// Cap for injected style content, in bytes (largest preset is ~8 KB).
+const STYLE_MAX_BYTES: usize = 9000;
+
+struct SeedStyle {
+    slug: &'static str,
+    name: &'static str,
+    description: &'static str,
+    source_name: &'static str,
+    source_url: &'static str,
+    license: &'static str,
+    content: &'static str,
+}
+
+/// Builtin presets. Content files carry their own attribution headers;
+/// the LICENSE file carries the full third-party notices.
+const SEED_STYLES: [SeedStyle; 6] = [
+    SeedStyle {
+        slug: "anthropic-frontend-design",
+        name: "Anthropic Frontend Design",
+        description: "Distinctive, production-grade UI direction from Anthropic's official frontend-design skill: deliberate palette, typography and layout choices that avoid templated AI aesthetics.",
+        source_name: "anthropics/skills — frontend-design",
+        source_url: "https://github.com/anthropics/skills",
+        license: "Apache-2.0",
+        content: include_str!("../../assets/design_styles/anthropic-frontend-design.md"),
+    },
+    SeedStyle {
+        slug: "taste-minimalist-editorial",
+        name: "Minimalist Editorial",
+        description: "Premium utilitarian minimalism: warm monochrome palette, editorial serif headings, flat bento grids, muted pastel accents, near-invisible motion.",
+        source_name: "Leonxlnx/taste-skill — minimalist-ui",
+        source_url: "https://github.com/Leonxlnx/taste-skill",
+        license: "MIT",
+        content: include_str!("../../assets/design_styles/taste-minimalist-editorial.md"),
+    },
+    SeedStyle {
+        slug: "taste-industrial-brutalist",
+        name: "Industrial Brutalist",
+        description: "Swiss industrial print meets tactical telemetry: rigid visible grids, extreme type-scale contrast, hazard-red accents, zero border radius, analog degradation textures.",
+        source_name: "Leonxlnx/taste-skill — industrial-brutalist-ui",
+        source_url: "https://github.com/Leonxlnx/taste-skill",
+        license: "MIT",
+        content: include_str!("../../assets/design_styles/taste-industrial-brutalist.md"),
+    },
+    SeedStyle {
+        slug: "taste-soft-premium",
+        name: "Soft Premium",
+        description: "Polished high-end aesthetic: soft depth, generous whitespace, refined gradients and spring-based motion.",
+        source_name: "Leonxlnx/taste-skill — soft-skill",
+        source_url: "https://github.com/Leonxlnx/taste-skill",
+        license: "MIT",
+        content: include_str!("../../assets/design_styles/taste-soft-premium.md"),
+    },
+    SeedStyle {
+        slug: "impeccable-design-language",
+        name: "Impeccable Design Language",
+        description: "Anti-pattern-driven design rules from pbakaus/impeccable: typography, color, spacing and motion constraints that keep AI-built UIs out of generic territory.",
+        source_name: "pbakaus/impeccable",
+        source_url: "https://github.com/pbakaus/impeccable",
+        license: "Apache-2.0",
+        content: include_str!("../../assets/design_styles/impeccable-design-language.md"),
+    },
+    SeedStyle {
+        slug: "emil-design-engineering",
+        name: "Emil Design Engineering",
+        description: "Animation and interaction craft from Emil Kowalski's design-engineering skill: precise durations and easings, purposeful motion, disciplined restraint.",
+        source_name: "emilkowalski/skills — emil-design-eng",
+        source_url: "https://github.com/emilkowalski/skills",
+        license: "MIT",
+        content: include_str!("../../assets/design_styles/emil-design-engineering.md"),
+    },
+];
+
+/// Idempotently seed / refresh the builtin presets. User `enabled` choices
+/// survive re-seeding; content and attribution follow the shipped assets.
+pub async fn ensure_builtin_styles(pool: &SqlitePool) -> anyhow::Result<()> {
+    for seed in &SEED_STYLES {
+        let content = super::architecture_knowledge::strip_attribution_header(seed.content).trim();
+        DesignStyle::upsert_builtin(
+            pool,
+            seed.slug,
+            seed.name,
+            seed.description,
+            content,
+            seed.source_name,
+            seed.source_url,
+            seed.license,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// Resolve the effective style for a draft: the draft's own selection, else
+/// the system default, else none. Disabled or missing styles resolve to
+/// none (fail-open, with a warning so the drop is observable).
+pub async fn resolve_style(
+    pool: &SqlitePool,
+    draft_style_slug: Option<&str>,
+) -> Option<DesignStyle> {
+    let slug = match draft_style_slug.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(slug) => Some(slug.to_string()),
+        None => match SystemSetting::get(pool, SETTING_DEFAULT_STYLE).await {
+            Ok(value) => value.map(|v| v.trim().to_string()).filter(|v| !v.is_empty()),
+            Err(e) => {
+                tracing::warn!("Failed to read {SETTING_DEFAULT_STYLE}: {e}");
+                None
+            }
+        },
+    }?;
+
+    match DesignStyle::find_enabled_by_slug(pool, &slug).await {
+        Ok(Some(style)) => Some(style),
+        Ok(None) => {
+            tracing::warn!(slug = %slug, "Selected design style missing or disabled; continuing without design direction");
+            None
+        }
+        Err(e) => {
+            tracing::warn!(slug = %slug, "Failed to resolve design style: {e}");
+            None
+        }
+    }
+}
+
+/// Render the prompt section carried inside the workflow goal.
+pub fn build_design_direction_section(style: &DesignStyle) -> String {
+    let content = style.content.trim();
+    let capped = if content.len() <= STYLE_MAX_BYTES {
+        content
+    } else {
+        &content[..content.floor_char_boundary(STYLE_MAX_BYTES)]
+    };
+    format!(
+        "## Design Direction (style: {name})\n\
+         All user-facing UI built for this project must follow the design direction below. \
+         Carry these constraints into every UI-related task instruction; non-UI tasks may \
+         ignore this section.\n\n{capped}",
+        name = style.name,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::query(
+            r"
+            CREATE TABLE design_style (
+                id TEXT PRIMARY KEY,
+                slug TEXT NOT NULL UNIQUE,
+                name TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                content TEXT NOT NULL,
+                source_name TEXT,
+                source_url TEXT,
+                license TEXT,
+                builtin INTEGER NOT NULL DEFAULT 0,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+                updated_at DATETIME NOT NULL DEFAULT (datetime('now'))
+            )
+            ",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r"
+            CREATE TABLE system_settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                description TEXT,
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+            ",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn seeds_builtin_styles_and_preserves_enabled() {
+        let pool = test_pool().await;
+        ensure_builtin_styles(&pool).await.unwrap();
+        let styles = DesignStyle::find_all(&pool).await.unwrap();
+        assert_eq!(styles.len(), SEED_STYLES.len());
+        assert!(styles.iter().all(|s| s.builtin && s.enabled));
+        assert!(styles.iter().all(|s| !s.content.starts_with("<!--")));
+        assert!(styles.iter().all(|s| s.license.is_some()));
+
+        // Disable one, re-seed, the choice must survive while content refreshes.
+        let target = &styles[0];
+        DesignStyle::set_enabled(&pool, &target.id, false).await.unwrap();
+        ensure_builtin_styles(&pool).await.unwrap();
+        let after = DesignStyle::find_by_slug(&pool, &target.slug)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!after.enabled, "re-seeding must not re-enable a disabled preset");
+        assert!(after.builtin);
+    }
+
+    #[tokio::test]
+    async fn resolve_precedence_draft_then_default_then_none() {
+        let pool = test_pool().await;
+        ensure_builtin_styles(&pool).await.unwrap();
+
+        // No selection anywhere → none.
+        assert!(resolve_style(&pool, None).await.is_none());
+
+        // System default applies when the draft has no selection.
+        SystemSetting::set(&pool, SETTING_DEFAULT_STYLE, "taste-minimalist-editorial")
+            .await
+            .unwrap();
+        let resolved = resolve_style(&pool, None).await.unwrap();
+        assert_eq!(resolved.slug, "taste-minimalist-editorial");
+
+        // Draft selection wins over the default.
+        let resolved = resolve_style(&pool, Some("emil-design-engineering")).await.unwrap();
+        assert_eq!(resolved.slug, "emil-design-engineering");
+
+        // Disabled style resolves to none.
+        let style = DesignStyle::find_by_slug(&pool, "emil-design-engineering")
+            .await
+            .unwrap()
+            .unwrap();
+        DesignStyle::set_enabled(&pool, &style.id, false).await.unwrap();
+        assert!(resolve_style(&pool, Some("emil-design-engineering")).await.is_none());
+
+        // Unknown slug resolves to none.
+        assert!(resolve_style(&pool, Some("no-such-style")).await.is_none());
+    }
+
+    #[test]
+    fn section_carries_style_name_and_content() {
+        let style = DesignStyle::new("s", "My Style", "d", "Use warm monochrome.");
+        let section = build_design_direction_section(&style);
+        assert!(section.starts_with("## Design Direction (style: My Style)"));
+        assert!(section.contains("Use warm monochrome."));
+        assert!(section.contains("non-UI tasks may"));
+    }
+}

--- a/crates/services/src/services/mod.rs
+++ b/crates/services/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod analytics;
 pub mod approvals;
+pub mod architecture_knowledge;
 pub mod auth;
 pub mod cc_switch;
 pub mod claude_models;
@@ -7,6 +8,7 @@ pub mod cli_health_monitor;
 pub mod cli_installer;
 pub mod config;
 pub mod container;
+pub mod design_direction;
 pub mod diff_stream;
 pub mod events;
 pub mod file_ranker;

--- a/crates/services/src/services/orchestrator/config.rs
+++ b/crates/services/src/services/orchestrator/config.rs
@@ -219,6 +219,11 @@ fail_workflow: {"type":"fail_workflow","reason":"..."}
 ## Workflow Slash Commands
 Workflows may configure slash commands (built-in presets or CLI plugin commands). They are delivered to you with the leading '/' removed so they cannot execute directly in this conversation. To invoke one on a terminal, prepend '/' to the command in the message you send, e.g. {"type":"send_to_terminal","terminal_id":"tm1","message":"/review"}. The terminal CLI recognizes and executes it natively.
 
+## Goal Context Sections
+The project goal may carry two optional sections. Honor both:
+- '## Architecture Guidance': a methodology checklist plus reference-architecture digests. Apply it when you fix the tech stack and decompose tasks — resolve its decision forks explicitly and reflect the outcomes (data models, boundaries, bottleneck mitigations) in task instructions.
+- '## Design Direction': the visual style contract for this project. Copy its constraints into EVERY terminal instruction that builds or modifies user-facing UI (including the foundation task's base styles). Non-UI instructions may omit it.
+
 ## Example Response (from-scratch)
 [
   {"type":"create_task","task_id":"task-1","name":"Foundation","branch":"feat/foundation","order_index":0},
@@ -382,6 +387,20 @@ mod tests {
         assert!(
             !planning.contains("## Workflow Slash Commands"),
             "planning prompt must not reference runtime slash-command handling"
+        );
+    }
+
+    #[test]
+    fn runtime_prompt_documents_goal_context_sections() {
+        let prompt = system_prompt_for_profile(PromptProfile::RuntimeOrchestrator);
+        assert!(prompt.contains("## Goal Context Sections"));
+        assert!(prompt.contains("## Architecture Guidance"));
+        assert!(prompt.contains("## Design Direction"));
+
+        let planning = system_prompt_for_profile(PromptProfile::WorkspacePlanning);
+        assert!(
+            !planning.contains("## Goal Context Sections"),
+            "planning prompt must not reference runtime goal sections"
         );
     }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import {
   FeishuSettingsNew,
   OrganizationSettingsNew,
   RuntimeSettingsNew,
+  ArchitectureSettingsNew,
+  DesignStylesSettingsNew,
 } from '@/pages/ui-new/settings';
 import { QualityGateSettingsNew } from '@/pages/ui-new/settings/QualityGateSettingsNew';
 import { UserSystemProvider, useUserSystem } from '@/components/ConfigProvider';
@@ -172,6 +174,14 @@ function AppContent() {
               <Route path="models" element={<ModelsSettingsNew />} />
               <Route path="mcp" element={<McpSettingsNew />} />
               <Route path="feishu" element={<FeishuSettingsNew />} />
+              <Route
+                path="architecture"
+                element={<ArchitectureSettingsNew />}
+              />
+              <Route
+                path="design-styles"
+                element={<DesignStylesSettingsNew />}
+              />
               <Route path="organizations" element={<OrganizationSettingsNew />} />
               <Route path="runtime" element={<RuntimeSettingsNew />} />
               <Route

--- a/frontend/src/components/ui-new/containers/CreateChatBoxContainer.tsx
+++ b/frontend/src/components/ui-new/containers/CreateChatBoxContainer.tsx
@@ -14,6 +14,7 @@ import type { ModelConfig as WorkflowModelConfig } from '@/components/workflow/t
 import { useModelConfigForExecutor } from '@/hooks/useModelConfigForExecutor';
 import {
   planningDraftsApi,
+  designStylesApi,
   feishuApi,
   type PlanningMessageResponse,
 } from '@/lib/api';
@@ -28,7 +29,10 @@ import {
   useMaterializeDraft,
   useTogglePlanningFeishuSync,
 } from '@/hooks/usePlanningDraft';
-import { CreateChatBox } from '../primitives/CreateChatBox';
+import {
+  CreateChatBox,
+  type DesignStyleOption,
+} from '../primitives/CreateChatBox';
 import { WelcomeHero } from '../primitives/WelcomeHero';
 import { AuditDocPanel } from './AuditDocPanel';
 import { AuditPlanCard } from './AuditPlanCard';
@@ -641,6 +645,60 @@ export function CreateChatBoxContainer() {
     [effectiveProfile?.executor, profiles]
   );
 
+  // Design style selection: null = follow the system default. Applied at
+  // draft creation; changing it later PUTs to the draft (pre-materialize).
+  const [designStyleSlug, setDesignStyleSlug] = useState<string | null>(null);
+  const [designStyleOptions, setDesignStyleOptions] = useState<
+    DesignStyleOption[]
+  >([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    designStylesApi
+      .list()
+      .then((styles) => {
+        if (cancelled) return;
+        setDesignStyleOptions(
+          styles
+            .filter((s) => s.enabled)
+            .map((s) => ({ slug: s.slug, name: s.name }))
+        );
+      })
+      .catch(() => {
+        // Selector simply stays hidden when styles can't be loaded.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Adopt the persisted selection when a draft loads or switches.
+  useEffect(() => {
+    setDesignStyleSlug(planningDraft?.designStyleSlug ?? null);
+  }, [planningDraft?.id, planningDraft?.designStyleSlug]);
+
+  const handleDesignStyleChange = useCallback(
+    async (slug: string | null) => {
+      const previous = designStyleSlug;
+      setDesignStyleSlug(slug);
+      if (!planningDraftId) return;
+      try {
+        await planningDraftsApi.updateDesignStyle(planningDraftId, slug);
+        queryClient.invalidateQueries({
+          queryKey: planningDraftKeys.byId(planningDraftId),
+        });
+      } catch (e) {
+        setDesignStyleSlug(previous);
+        const err = e as { message?: string };
+        showToast(
+          err.message ?? tTasks('conversation.designStyle.updateError'),
+          'error'
+        );
+      }
+    },
+    [designStyleSlug, planningDraftId, queryClient, showToast, tTasks]
+  );
+
   const hasChangedFromDefault = useMemo(
     () => checkProfileChanged(effectiveProfile, config?.executor_profile),
     [effectiveProfile, config?.executor_profile]
@@ -736,6 +794,7 @@ export function CreateChatBoxContainer() {
         plannerApiType: modelConfig?.apiType,
         plannerBaseUrl: modelConfig?.baseUrl,
         plannerApiKey: modelConfig?.apiKey,
+        designStyleSlug: designStyleSlug ?? undefined,
       });
       setPlanningDraftId(draft.id);
 
@@ -768,6 +827,7 @@ export function CreateChatBoxContainer() {
     effectiveProfile,
     updateAndSaveConfig,
     selectedPlannerModelConfig,
+    designStyleSlug,
     setPlanningDraftId,
     setMessage,
     clearAttachments,
@@ -994,6 +1054,11 @@ export function CreateChatBoxContainer() {
                         }
                       : undefined
                   }
+                  designStyle={{
+                    options: designStyleOptions,
+                    selectedSlug: designStyleSlug,
+                    onChange: handleDesignStyleChange,
+                  }}
                   variant={
                     effectiveProfile
                       ? {
@@ -1045,6 +1110,11 @@ export function CreateChatBoxContainer() {
                     }
                   : undefined
               }
+              designStyle={{
+                options: designStyleOptions,
+                selectedSlug: designStyleSlug,
+                onChange: handleDesignStyleChange,
+              }}
               variant={
                 effectiveProfile
                   ? {

--- a/frontend/src/components/ui-new/containers/SettingsLayoutContainer.tsx
+++ b/frontend/src/components/ui-new/containers/SettingsLayoutContainer.tsx
@@ -12,6 +12,8 @@ import {
   BuildingsIcon,
   HardDrivesIcon,
   ShieldCheckIcon,
+  TreeStructureIcon,
+  PaletteIcon,
 } from '@phosphor-icons/react';
 import { useUserSystem } from '@/components/ConfigProvider';
 import { SettingsLayout, type SettingsNavItem } from '../views/SettingsLayout';
@@ -58,6 +60,16 @@ export function SettingsLayoutContainer() {
         path: 'feishu',
         label: t('settings:newDesign.nav.feishu'),
         icon: ChatTeardropDotsIcon,
+      },
+      {
+        path: 'architecture',
+        label: t('settings:newDesign.nav.architecture'),
+        icon: TreeStructureIcon,
+      },
+      {
+        path: 'design-styles',
+        label: t('settings:newDesign.nav.designStyles'),
+        icon: PaletteIcon,
       },
       {
         path: 'runtime',

--- a/frontend/src/components/ui-new/primitives/CreateChatBox.tsx
+++ b/frontend/src/components/ui-new/primitives/CreateChatBox.tsx
@@ -40,6 +40,18 @@ export interface SaveAsDefaultProps {
   visible: boolean;
 }
 
+export interface DesignStyleOption {
+  slug: string;
+  name: string;
+}
+
+export interface DesignStyleProps {
+  options: DesignStyleOption[];
+  /** null = follow the system default style. */
+  selectedSlug: string | null;
+  onChange: (slug: string | null) => void;
+}
+
 interface CreateChatBoxProps {
   readonly editor: EditorProps;
   readonly onSend: () => void;
@@ -48,6 +60,7 @@ interface CreateChatBoxProps {
   readonly placeholder?: string;
   readonly executor: ExecutorProps;
   readonly modelConfig?: ModelConfigProps;
+  readonly designStyle?: DesignStyleProps;
   readonly variant?: VariantProps;
   readonly saveAsDefault?: SaveAsDefaultProps;
   readonly error?: string | null;
@@ -72,6 +85,7 @@ export function CreateChatBox({
   placeholder,
   executor,
   modelConfig,
+  designStyle,
   variant,
   saveAsDefault,
   error,
@@ -198,6 +212,39 @@ export function CreateChatBox({
                   ))}
                 </>
               )}
+            </ToolbarDropdown>
+          )}
+          {designStyle && designStyle.options.length > 0 && (
+            <ToolbarDropdown
+              label={
+                designStyle.options.find(
+                  (s) => s.slug === designStyle.selectedSlug
+                )?.name ?? t('conversation.designStyle.defaultOption')
+              }
+            >
+              <DropdownMenuLabel>
+                {t('conversation.designStyle.label')}
+              </DropdownMenuLabel>
+              <DropdownMenuItem
+                icon={designStyle.selectedSlug === null ? CheckIcon : undefined}
+                onClick={() => designStyle.onChange(null)}
+              >
+                {t('conversation.designStyle.defaultOption')}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              {designStyle.options.map((style) => (
+                <DropdownMenuItem
+                  key={style.slug}
+                  icon={
+                    designStyle.selectedSlug === style.slug
+                      ? CheckIcon
+                      : undefined
+                  }
+                  onClick={() => designStyle.onChange(style.slug)}
+                >
+                  {style.name}
+                </DropdownMenuItem>
+              ))}
             </ToolbarDropdown>
           )}
           {saveAsDefault?.visible && (

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -470,6 +470,83 @@
         "saveError": "Failed to save Feishu configuration.",
         "requiredFields": "App ID and App Secret are required."
       }
+    },
+    "designStyles": {
+      "title": "Design Styles",
+      "loadError": "Failed to load design styles",
+      "saveError": "Failed to save design style",
+      "deleteError": "Failed to delete design style",
+      "copyName": "{{name}} (copy)",
+      "defaultNone": "None (no design direction)",
+      "defaultCard": {
+        "title": "Default design style",
+        "description": "Applied to new orchestration rounds that do not pick their own style.",
+        "label": "Default style"
+      },
+      "listCard": {
+        "title": "Style library",
+        "description": "Built-in presets are adapted from high-rated open-source design skills (see LICENSE). Duplicate one to customize it, or create your own."
+      },
+      "badge": {
+        "builtin": "Built-in",
+        "custom": "Custom"
+      },
+      "sourceLabel": "Source: {{source}}",
+      "actions": {
+        "viewContent": "View content",
+        "duplicate": "Duplicate",
+        "edit": "Edit",
+        "delete": "Delete",
+        "create": "New style"
+      },
+      "editor": {
+        "createTitle": "Create design style",
+        "editTitle": "Edit design style",
+        "nameLabel": "Name",
+        "descriptionLabel": "Description",
+        "contentLabel": "Style directives",
+        "contentHint": "Prompt text injected for UI-related work: palette, typography, spacing and motion rules.",
+        "requiredFields": "Name and style directives are required"
+      }
+    },
+    "architecture": {
+      "title": "Architecture Knowledge",
+      "loadError": "Failed to load architecture settings",
+      "saveError": "Failed to save changes",
+      "syncError": "Sync failed",
+      "deleteError": "Failed to delete source",
+      "guidanceCard": {
+        "title": "Planning guidance",
+        "description": "Injects an architecture-thinking checklist plus matched reference-architecture digests into the planner when a round is materialized.",
+        "toggleLabel": "Enable architecture guidance",
+        "toggleDescription": "Methodology adapted from architecture-copilot; reference templates sync from the knowledge sources below."
+      },
+      "sourcesCard": {
+        "title": "Knowledge sources",
+        "description": "GitHub repositories synced into the local knowledge base. The built-in source is awesome-architecture (MIT); you can add your own."
+      },
+      "source": {
+        "builtinBadge": "Built-in",
+        "paths": "Paths: {{paths}}",
+        "entryCount": "{{count}} entries",
+        "lastSync": "Last sync: {{time}}",
+        "neverSynced": "Never synced"
+      },
+      "actions": {
+        "syncNow": "Sync now",
+        "delete": "Delete",
+        "addSource": "Add source"
+      },
+      "addDialog": {
+        "title": "Add knowledge source",
+        "nameLabel": "Display name",
+        "ownerLabel": "GitHub owner",
+        "repoLabel": "Repository",
+        "branchLabel": "Branch",
+        "includePathsLabel": "Include paths (comma-separated)",
+        "includePathsHint": "Only markdown files under these directory prefixes are synced, e.g. \"templates/\".",
+        "requiredFields": "Name, owner and repository are required"
+      }
     }
   },
   "integrations": {
@@ -523,7 +600,9 @@
       "feishu": "Feishu",
       "runtime": "Runtime",
       "qualityGates": "Quality Gates",
-      "organizations": "Organizations"
+      "organizations": "Organizations",
+      "architecture": "Architecture",
+      "designStyles": "Design Styles"
     },
     "common": {
       "save": "Save Changes",

--- a/frontend/src/i18n/locales/en/tasks.json
+++ b/frontend/src/i18n/locales/en/tasks.json
@@ -401,7 +401,12 @@
     },
     "updatedTodos": "Updated Todos",
     "viewInChangesPanel": "View in changes panel",
-    "unableToRenderDiff": "Unable to render diff."
+    "unableToRenderDiff": "Unable to render diff.",
+    "designStyle": {
+      "label": "Design style",
+      "defaultOption": "Default style",
+      "updateError": "Failed to update design style"
+    }
   },
   "attempt": {
     "actions": {

--- a/frontend/src/i18n/locales/es/settings.json
+++ b/frontend/src/i18n/locales/es/settings.json
@@ -386,6 +386,83 @@
         "discard": "Descartar",
         "confirmSwitch": "Tienes cambios sin guardar. ¿Estás seguro de que quieres cambiar de repositorio? Tus cambios se perderán."
       }
+    },
+    "designStyles": {
+      "title": "Estilos de diseño",
+      "loadError": "No se pudieron cargar los estilos de diseño",
+      "saveError": "No se pudo guardar el estilo de diseño",
+      "deleteError": "No se pudo eliminar el estilo de diseño",
+      "copyName": "{{name}} (copia)",
+      "defaultNone": "Ninguno (sin dirección de diseño)",
+      "defaultCard": {
+        "title": "Estilo de diseño predeterminado",
+        "description": "Se aplica a las nuevas rondas de orquestación que no elijan su propio estilo.",
+        "label": "Estilo predeterminado"
+      },
+      "listCard": {
+        "title": "Biblioteca de estilos",
+        "description": "Los preajustes integrados están adaptados de skills de diseño de código abierto muy valoradas (ver LICENSE). Duplica uno para personalizarlo o crea el tuyo."
+      },
+      "badge": {
+        "builtin": "Integrado",
+        "custom": "Personalizado"
+      },
+      "sourceLabel": "Fuente: {{source}}",
+      "actions": {
+        "viewContent": "Ver contenido",
+        "duplicate": "Duplicar",
+        "edit": "Editar",
+        "delete": "Eliminar",
+        "create": "Nuevo estilo"
+      },
+      "editor": {
+        "createTitle": "Crear estilo de diseño",
+        "editTitle": "Editar estilo de diseño",
+        "nameLabel": "Nombre",
+        "descriptionLabel": "Descripción",
+        "contentLabel": "Directrices de estilo",
+        "contentHint": "Texto de prompt inyectado en tareas de UI: paleta, tipografía, espaciado y reglas de movimiento.",
+        "requiredFields": "El nombre y las directrices de estilo son obligatorios"
+      }
+    },
+    "architecture": {
+      "title": "Base de conocimiento de arquitectura",
+      "loadError": "No se pudo cargar la configuración de arquitectura",
+      "saveError": "No se pudieron guardar los cambios",
+      "syncError": "La sincronización falló",
+      "deleteError": "No se pudo eliminar la fuente",
+      "guidanceCard": {
+        "title": "Guía de planificación",
+        "description": "Inyecta una lista de verificación de pensamiento arquitectónico y resúmenes de arquitecturas de referencia coincidentes al planificador al materializar una ronda.",
+        "toggleLabel": "Activar guía de arquitectura",
+        "toggleDescription": "Metodología adaptada de architecture-copilot; las plantillas de referencia se sincronizan desde las fuentes de conocimiento de abajo."
+      },
+      "sourcesCard": {
+        "title": "Fuentes de conocimiento",
+        "description": "Repositorios de GitHub sincronizados con la base de conocimiento local. La fuente integrada es awesome-architecture (MIT); puedes añadir las tuyas."
+      },
+      "source": {
+        "builtinBadge": "Integrada",
+        "paths": "Rutas: {{paths}}",
+        "entryCount": "{{count}} entradas",
+        "lastSync": "Última sincronización: {{time}}",
+        "neverSynced": "Nunca sincronizada"
+      },
+      "actions": {
+        "syncNow": "Sincronizar ahora",
+        "delete": "Eliminar",
+        "addSource": "Añadir fuente"
+      },
+      "addDialog": {
+        "title": "Añadir fuente de conocimiento",
+        "nameLabel": "Nombre para mostrar",
+        "ownerLabel": "Propietario de GitHub",
+        "repoLabel": "Repositorio",
+        "branchLabel": "Rama",
+        "includePathsLabel": "Rutas incluidas (separadas por comas)",
+        "includePathsHint": "Solo se sincronizan los archivos Markdown bajo estos prefijos de directorio, p. ej. \"templates/\".",
+        "requiredFields": "El nombre, el propietario y el repositorio son obligatorios"
+      }
     }
   },
   "integrations": {
@@ -438,7 +515,9 @@
       "mcp": "Servidores MCP",
       "feishu": "Feishu",
       "qualityGates": "Quality Gates",
-      "organizations": "Organizaciones"
+      "organizations": "Organizaciones",
+      "architecture": "Arquitectura",
+      "designStyles": "Estilos de diseño"
     },
     "common": {
       "save": "Guardar cambios",

--- a/frontend/src/i18n/locales/es/tasks.json
+++ b/frontend/src/i18n/locales/es/tasks.json
@@ -773,6 +773,11 @@
       "modified": "Modificado",
       "deleted": "Eliminado",
       "renamed": "Renombrado"
+    },
+    "designStyle": {
+      "label": "Estilo de diseño",
+      "defaultOption": "Estilo predeterminado",
+      "updateError": "No se pudo actualizar el estilo de diseño"
     }
   },
   "scriptFixer": {

--- a/frontend/src/i18n/locales/ja/settings.json
+++ b/frontend/src/i18n/locales/ja/settings.json
@@ -386,6 +386,83 @@
         "discard": "破棄",
         "confirmSwitch": "未保存の変更があります。本当にリポジトリを切り替えますか？変更は失われます。"
       }
+    },
+    "designStyles": {
+      "title": "デザインスタイル",
+      "loadError": "デザインスタイルの読み込みに失敗しました",
+      "saveError": "デザインスタイルの保存に失敗しました",
+      "deleteError": "デザインスタイルの削除に失敗しました",
+      "copyName": "{{name}}（コピー）",
+      "defaultNone": "なし（デザイン指示を注入しない）",
+      "defaultCard": {
+        "title": "デフォルトのデザインスタイル",
+        "description": "スタイルを個別に選択しなかった新しいオーケストレーションラウンドに適用されます。",
+        "label": "デフォルトスタイル"
+      },
+      "listCard": {
+        "title": "スタイルライブラリ",
+        "description": "組み込みプリセットは高評価のオープンソースデザインスキルを改変したものです（LICENSE 参照）。複製してカスタマイズするか、独自に作成できます。"
+      },
+      "badge": {
+        "builtin": "組み込み",
+        "custom": "カスタム"
+      },
+      "sourceLabel": "出典：{{source}}",
+      "actions": {
+        "viewContent": "内容を表示",
+        "duplicate": "複製",
+        "edit": "編集",
+        "delete": "削除",
+        "create": "新規スタイル"
+      },
+      "editor": {
+        "createTitle": "デザインスタイルを作成",
+        "editTitle": "デザインスタイルを編集",
+        "nameLabel": "名前",
+        "descriptionLabel": "説明",
+        "contentLabel": "スタイル指示",
+        "contentHint": "UI 関連タスクに注入されるプロンプト：配色、タイポグラフィ、余白、モーションのルールなど。",
+        "requiredFields": "名前とスタイル指示は必須です"
+      }
+    },
+    "architecture": {
+      "title": "アーキテクチャ知識ベース",
+      "loadError": "アーキテクチャ設定の読み込みに失敗しました",
+      "saveError": "保存に失敗しました",
+      "syncError": "同期に失敗しました",
+      "deleteError": "ソースの削除に失敗しました",
+      "guidanceCard": {
+        "title": "プランニングガイダンス",
+        "description": "ラウンドの実体化時に、アーキテクチャ思考チェックリストとマッチした参照アーキテクチャの要約をプランナーに注入します。",
+        "toggleLabel": "アーキテクチャガイダンスを有効化",
+        "toggleDescription": "方法論は architecture-copilot を改変。参照テンプレートは下記の知識ソースから同期されます。"
+      },
+      "sourcesCard": {
+        "title": "知識ソース",
+        "description": "ローカル知識ベースに同期される GitHub リポジトリ。組み込みソースは awesome-architecture（MIT）です。独自のリポジトリも追加できます。"
+      },
+      "source": {
+        "builtinBadge": "組み込み",
+        "paths": "パス：{{paths}}",
+        "entryCount": "{{count}} 件のエントリ",
+        "lastSync": "最終同期：{{time}}",
+        "neverSynced": "未同期"
+      },
+      "actions": {
+        "syncNow": "今すぐ同期",
+        "delete": "削除",
+        "addSource": "ソースを追加"
+      },
+      "addDialog": {
+        "title": "知識ソースを追加",
+        "nameLabel": "表示名",
+        "ownerLabel": "GitHub オーナー",
+        "repoLabel": "リポジトリ",
+        "branchLabel": "ブランチ",
+        "includePathsLabel": "対象パス（カンマ区切り）",
+        "includePathsHint": "これらのディレクトリ接頭辞配下の Markdown ファイルのみ同期されます。例：\"templates/\"。",
+        "requiredFields": "表示名・オーナー・リポジトリは必須です"
+      }
     }
   },
   "integrations": {
@@ -438,7 +515,9 @@
       "mcp": "MCPサーバー",
       "feishu": "Feishu",
       "qualityGates": "Quality Gates",
-      "organizations": "組織"
+      "organizations": "組織",
+      "architecture": "アーキテクチャ",
+      "designStyles": "デザインスタイル"
     },
     "common": {
       "save": "変更を保存",

--- a/frontend/src/i18n/locales/ja/tasks.json
+++ b/frontend/src/i18n/locales/ja/tasks.json
@@ -773,6 +773,11 @@
       "modified": "変更済み",
       "deleted": "削除済み",
       "renamed": "名前変更済み"
+    },
+    "designStyle": {
+      "label": "デザインスタイル",
+      "defaultOption": "デフォルトスタイル",
+      "updateError": "デザインスタイルの更新に失敗しました"
     }
   },
   "scriptFixer": {

--- a/frontend/src/i18n/locales/ko/settings.json
+++ b/frontend/src/i18n/locales/ko/settings.json
@@ -386,6 +386,83 @@
         "discard": "취소",
         "confirmSwitch": "저장되지 않은 변경사항이 있습니다. 정말 저장소를 전환하시겠습니까? 변경사항이 손실됩니다."
       }
+    },
+    "designStyles": {
+      "title": "디자인 스타일",
+      "loadError": "디자인 스타일을 불러오지 못했습니다",
+      "saveError": "디자인 스타일 저장에 실패했습니다",
+      "deleteError": "디자인 스타일 삭제에 실패했습니다",
+      "copyName": "{{name}} (복사본)",
+      "defaultNone": "없음 (디자인 지시 미주입)",
+      "defaultCard": {
+        "title": "기본 디자인 스타일",
+        "description": "스타일을 따로 선택하지 않은 새 오케스트레이션 라운드에 적용됩니다.",
+        "label": "기본 스타일"
+      },
+      "listCard": {
+        "title": "스타일 라이브러리",
+        "description": "기본 프리셋은 높은 평가를 받은 오픈소스 디자인 스킬을 각색한 것입니다(LICENSE 참조). 복제하여 수정하거나 직접 만들 수 있습니다."
+      },
+      "badge": {
+        "builtin": "기본 제공",
+        "custom": "사용자 정의"
+      },
+      "sourceLabel": "출처: {{source}}",
+      "actions": {
+        "viewContent": "내용 보기",
+        "duplicate": "복제",
+        "edit": "편집",
+        "delete": "삭제",
+        "create": "새 스타일"
+      },
+      "editor": {
+        "createTitle": "디자인 스타일 만들기",
+        "editTitle": "디자인 스타일 편집",
+        "nameLabel": "이름",
+        "descriptionLabel": "설명",
+        "contentLabel": "스타일 지시문",
+        "contentHint": "UI 관련 작업에 주입되는 프롬프트: 색상, 타이포그래피, 간격, 모션 규칙 등.",
+        "requiredFields": "이름과 스타일 지시문은 필수입니다"
+      }
+    },
+    "architecture": {
+      "title": "아키텍처 지식 베이스",
+      "loadError": "아키텍처 설정을 불러오지 못했습니다",
+      "saveError": "저장에 실패했습니다",
+      "syncError": "동기화에 실패했습니다",
+      "deleteError": "소스 삭제에 실패했습니다",
+      "guidanceCard": {
+        "title": "플래닝 가이드",
+        "description": "라운드 구체화 시 아키텍처 사고 체크리스트와 매칭된 참조 아키텍처 요약을 플래너에 주입합니다.",
+        "toggleLabel": "아키텍처 가이드 사용",
+        "toggleDescription": "방법론은 architecture-copilot을 각색했습니다. 참조 템플릿은 아래 지식 소스에서 동기화됩니다."
+      },
+      "sourcesCard": {
+        "title": "지식 소스",
+        "description": "로컬 지식 베이스로 동기화되는 GitHub 저장소입니다. 기본 소스는 awesome-architecture(MIT)이며, 직접 추가할 수도 있습니다."
+      },
+      "source": {
+        "builtinBadge": "기본 제공",
+        "paths": "경로: {{paths}}",
+        "entryCount": "{{count}}개 항목",
+        "lastSync": "마지막 동기화: {{time}}",
+        "neverSynced": "동기화된 적 없음"
+      },
+      "actions": {
+        "syncNow": "지금 동기화",
+        "delete": "삭제",
+        "addSource": "소스 추가"
+      },
+      "addDialog": {
+        "title": "지식 소스 추가",
+        "nameLabel": "표시 이름",
+        "ownerLabel": "GitHub 소유자",
+        "repoLabel": "저장소",
+        "branchLabel": "브랜치",
+        "includePathsLabel": "포함 경로 (쉼표로 구분)",
+        "includePathsHint": "이 디렉터리 접두사 아래의 Markdown 파일만 동기화됩니다. 예: \"templates/\".",
+        "requiredFields": "표시 이름, 소유자, 저장소는 필수입니다"
+      }
     }
   },
   "integrations": {
@@ -438,7 +515,9 @@
       "mcp": "MCP 서버",
       "feishu": "Feishu",
       "qualityGates": "Quality Gates",
-      "organizations": "조직"
+      "organizations": "조직",
+      "architecture": "아키텍처",
+      "designStyles": "디자인 스타일"
     },
     "common": {
       "save": "변경사항 저장",

--- a/frontend/src/i18n/locales/ko/tasks.json
+++ b/frontend/src/i18n/locales/ko/tasks.json
@@ -773,6 +773,11 @@
       "modified": "수정됨",
       "deleted": "삭제됨",
       "renamed": "이름 변경됨"
+    },
+    "designStyle": {
+      "label": "디자인 스타일",
+      "defaultOption": "기본 스타일",
+      "updateError": "디자인 스타일 업데이트에 실패했습니다"
     }
   },
   "scriptFixer": {

--- a/frontend/src/i18n/locales/zh-Hans/settings.json
+++ b/frontend/src/i18n/locales/zh-Hans/settings.json
@@ -470,6 +470,83 @@
         "saveError": "保存飞书配置失败。",
         "requiredFields": "应用 ID 和应用密钥为必填项。"
       }
+    },
+    "designStyles": {
+      "title": "设计风格",
+      "loadError": "加载设计风格失败",
+      "saveError": "保存设计风格失败",
+      "deleteError": "删除设计风格失败",
+      "copyName": "{{name}}（副本）",
+      "defaultNone": "无（不注入设计方向）",
+      "defaultCard": {
+        "title": "默认设计风格",
+        "description": "新的编排回合未单独选择风格时，将采用此默认风格。",
+        "label": "默认风格"
+      },
+      "listCard": {
+        "title": "风格库",
+        "description": "内置预设改编自高星开源设计 Skill（见 LICENSE）。可复制后自定义，也可以新建自己的风格。"
+      },
+      "badge": {
+        "builtin": "内置",
+        "custom": "自定义"
+      },
+      "sourceLabel": "来源：{{source}}",
+      "actions": {
+        "viewContent": "查看内容",
+        "duplicate": "复制",
+        "edit": "编辑",
+        "delete": "删除",
+        "create": "新建风格"
+      },
+      "editor": {
+        "createTitle": "新建设计风格",
+        "editTitle": "编辑设计风格",
+        "nameLabel": "名称",
+        "descriptionLabel": "描述",
+        "contentLabel": "风格指令",
+        "contentHint": "注入到 UI 相关任务的提示词：配色、字体、间距与动效规则等。",
+        "requiredFields": "名称和风格指令为必填项"
+      }
+    },
+    "architecture": {
+      "title": "架构知识库",
+      "loadError": "加载架构设置失败",
+      "saveError": "保存失败",
+      "syncError": "同步失败",
+      "deleteError": "删除知识源失败",
+      "guidanceCard": {
+        "title": "规划引导",
+        "description": "在回合物化时，将架构思维清单与匹配到的参考架构摘要注入给规划器。",
+        "toggleLabel": "启用架构引导",
+        "toggleDescription": "方法论改编自 architecture-copilot；参考模板从下方知识源同步。"
+      },
+      "sourcesCard": {
+        "title": "知识源",
+        "description": "同步到本地知识库的 GitHub 仓库。内置源为 awesome-architecture（MIT），也可以添加自己的仓库。"
+      },
+      "source": {
+        "builtinBadge": "内置",
+        "paths": "路径：{{paths}}",
+        "entryCount": "{{count}} 个条目",
+        "lastSync": "上次同步：{{time}}",
+        "neverSynced": "尚未同步"
+      },
+      "actions": {
+        "syncNow": "立即同步",
+        "delete": "删除",
+        "addSource": "添加知识源"
+      },
+      "addDialog": {
+        "title": "添加知识源",
+        "nameLabel": "显示名称",
+        "ownerLabel": "GitHub 所有者",
+        "repoLabel": "仓库名",
+        "branchLabel": "分支",
+        "includePathsLabel": "包含路径（逗号分隔）",
+        "includePathsHint": "仅同步这些目录前缀下的 Markdown 文件，例如 \"templates/\"。",
+        "requiredFields": "名称、所有者和仓库名为必填项"
+      }
     }
   },
   "integrations": {
@@ -523,7 +600,9 @@
       "feishu": "飞书",
       "runtime": "运行环境",
       "qualityGates": "质量门禁",
-      "organizations": "组织"
+      "organizations": "组织",
+      "architecture": "架构知识",
+      "designStyles": "设计风格"
     },
     "common": {
       "save": "保存更改",

--- a/frontend/src/i18n/locales/zh-Hans/tasks.json
+++ b/frontend/src/i18n/locales/zh-Hans/tasks.json
@@ -794,7 +794,12 @@
     "saveAsDefault": "设为默认",
     "updatedTodos": "更新的待办事项",
     "viewInChangesPanel": "在更改面板中查看",
-    "unableToRenderDiff": "无法显示差异。"
+    "unableToRenderDiff": "无法显示差异。",
+    "designStyle": {
+      "label": "设计风格",
+      "defaultOption": "默认风格",
+      "updateError": "更新设计风格失败"
+    }
   },
   "scriptFixer": {
     "title": "修复脚本",

--- a/frontend/src/i18n/locales/zh-Hant/settings.json
+++ b/frontend/src/i18n/locales/zh-Hant/settings.json
@@ -244,7 +244,7 @@
       "installAiCli": "一鍵安裝 AI CLI",
       "refreshAvailability": "重新整理可用性",
       "installAiCliSuccess": "AI CLI 安裝完成。",
-      "installAiCliInstalledList": "\u5df2\u5b89\u88dd\u6210\u529f\uff1a{{names}}",
+      "installAiCliInstalledList": "已安裝成功：{{names}}",
       "installAiCliFailed": "AI CLI 安裝失敗。",
       "installAiCliExitCode": "退出碼：{{code}}",
       "installAiCliInProgress": "正在安裝 AI CLI，已耗時 {{seconds}} 秒",
@@ -397,6 +397,83 @@
         "discard": "放棄",
         "confirmSwitch": "您有未儲存的變更。確定要切換儲存庫嗎？您的變更將會遺失。"
       }
+    },
+    "designStyles": {
+      "title": "設計風格",
+      "loadError": "載入設計風格失敗",
+      "saveError": "儲存設計風格失敗",
+      "deleteError": "刪除設計風格失敗",
+      "copyName": "{{name}}（副本）",
+      "defaultNone": "無（不注入設計方向）",
+      "defaultCard": {
+        "title": "預設設計風格",
+        "description": "新的編排回合未單獨選擇風格時，將採用此預設風格。",
+        "label": "預設風格"
+      },
+      "listCard": {
+        "title": "風格庫",
+        "description": "內建預設改編自高星開源設計 Skill（見 LICENSE）。可複製後自訂，也可以建立自己的風格。"
+      },
+      "badge": {
+        "builtin": "內建",
+        "custom": "自訂"
+      },
+      "sourceLabel": "來源：{{source}}",
+      "actions": {
+        "viewContent": "檢視內容",
+        "duplicate": "複製",
+        "edit": "編輯",
+        "delete": "刪除",
+        "create": "新增風格"
+      },
+      "editor": {
+        "createTitle": "新增設計風格",
+        "editTitle": "編輯設計風格",
+        "nameLabel": "名稱",
+        "descriptionLabel": "描述",
+        "contentLabel": "風格指令",
+        "contentHint": "注入到 UI 相關任務的提示詞：配色、字體、間距與動效規則等。",
+        "requiredFields": "名稱和風格指令為必填項"
+      }
+    },
+    "architecture": {
+      "title": "架構知識庫",
+      "loadError": "載入架構設定失敗",
+      "saveError": "儲存失敗",
+      "syncError": "同步失敗",
+      "deleteError": "刪除知識來源失敗",
+      "guidanceCard": {
+        "title": "規劃引導",
+        "description": "在回合物化時，將架構思維清單與匹配到的參考架構摘要注入給規劃器。",
+        "toggleLabel": "啟用架構引導",
+        "toggleDescription": "方法論改編自 architecture-copilot；參考範本從下方知識來源同步。"
+      },
+      "sourcesCard": {
+        "title": "知識來源",
+        "description": "同步到本地知識庫的 GitHub 儲存庫。內建來源為 awesome-architecture（MIT），也可以新增自己的儲存庫。"
+      },
+      "source": {
+        "builtinBadge": "內建",
+        "paths": "路徑：{{paths}}",
+        "entryCount": "{{count}} 個條目",
+        "lastSync": "上次同步：{{time}}",
+        "neverSynced": "尚未同步"
+      },
+      "actions": {
+        "syncNow": "立即同步",
+        "delete": "刪除",
+        "addSource": "新增知識來源"
+      },
+      "addDialog": {
+        "title": "新增知識來源",
+        "nameLabel": "顯示名稱",
+        "ownerLabel": "GitHub 擁有者",
+        "repoLabel": "儲存庫名稱",
+        "branchLabel": "分支",
+        "includePathsLabel": "包含路徑（逗號分隔）",
+        "includePathsHint": "僅同步這些目錄前綴下的 Markdown 檔案，例如 \"templates/\"。",
+        "requiredFields": "名稱、擁有者和儲存庫名稱為必填項"
+      }
     }
   },
   "integrations": {
@@ -449,7 +526,9 @@
       "mcp": "MCP 伺服器",
       "feishu": "飛書",
       "qualityGates": "品質門禁",
-      "organizations": "組織"
+      "organizations": "組織",
+      "architecture": "架構知識",
+      "designStyles": "設計風格"
     },
     "common": {
       "save": "儲存變更",

--- a/frontend/src/i18n/locales/zh-Hant/tasks.json
+++ b/frontend/src/i18n/locales/zh-Hant/tasks.json
@@ -773,6 +773,11 @@
       "modified": "已修改",
       "deleted": "已刪除",
       "renamed": "已重新命名"
+    },
+    "designStyle": {
+      "label": "設計風格",
+      "defaultOption": "預設風格",
+      "updateError": "更新設計風格失敗"
     }
   },
   "scriptFixer": {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -548,6 +548,8 @@ export interface PlanningDraftResponse {
   auditPlan: string | null;
   auditMode: 'builtin' | 'merged' | 'custom';
   auditDocPath: string | null;
+  /** Selected design style slug; null falls back to the system default. */
+  designStyleSlug: string | null;
   gatesConfirmedAt: string | null;
   createdAt: string;
   updatedAt: string;
@@ -634,6 +636,7 @@ export const planningDraftsApi = {
     plannerApiType?: string;
     plannerBaseUrl?: string;
     plannerApiKey?: string;
+    designStyleSlug?: string;
   }): Promise<PlanningDraftResponse> => {
     const response = await makeRequest('/api/planning-drafts', {
       method: 'POST',
@@ -674,6 +677,18 @@ export const planningDraftsApi = {
     const response = await makeRequest(
       `/api/planning-drafts/${draftId}/confirm`,
       { method: 'POST', body: JSON.stringify({ retainBuiltin: retainBuiltin ?? true }) }
+    );
+    return handleApiResponse<PlanningDraftResponse>(response);
+  },
+
+  /** Set or clear the draft's design style (null clears the selection). */
+  updateDesignStyle: async (
+    draftId: string,
+    designStyleSlug: string | null
+  ): Promise<PlanningDraftResponse> => {
+    const response = await makeRequest(
+      `/api/planning-drafts/${draftId}/design-style`,
+      { method: 'PUT', body: JSON.stringify({ designStyleSlug }) }
     );
     return handleApiResponse<PlanningDraftResponse>(response);
   },
@@ -738,6 +753,151 @@ export const planningDraftsApi = {
       body: config ? JSON.stringify(config) : undefined,
     });
     return handleApiResponse<PlanningDraftResponse>(response);
+  },
+};
+
+// Design styles: builtin presets (license-attributed) + user-defined styles.
+export interface DesignStyleResponse {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  content: string;
+  sourceName: string | null;
+  sourceUrl: string | null;
+  license: string | null;
+  builtin: boolean;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const designStylesApi = {
+  list: async (): Promise<DesignStyleResponse[]> => {
+    const response = await makeRequest('/api/design-styles');
+    return handleApiResponse<DesignStyleResponse[]>(response);
+  },
+
+  create: async (data: {
+    name: string;
+    slug?: string;
+    description?: string;
+    content: string;
+  }): Promise<DesignStyleResponse> => {
+    const response = await makeRequest('/api/design-styles', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+    return handleApiResponse<DesignStyleResponse>(response);
+  },
+
+  update: async (
+    styleId: string,
+    data: {
+      name?: string;
+      description?: string;
+      content?: string;
+      enabled?: boolean;
+    }
+  ): Promise<DesignStyleResponse> => {
+    const response = await makeRequest(`/api/design-styles/${styleId}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+    return handleApiResponse<DesignStyleResponse>(response);
+  },
+
+  remove: async (styleId: string): Promise<void> => {
+    const response = await makeRequest(`/api/design-styles/${styleId}`, {
+      method: 'DELETE',
+    });
+    return handleApiResponse<void>(response);
+  },
+};
+
+// Architecture knowledge: GitHub-synced sources feeding planner guidance.
+export interface ArchitectureSourceResponse {
+  id: string;
+  name: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  includePaths: string[];
+  enabled: boolean;
+  builtin: boolean;
+  lastSyncedAt: string | null;
+  lastSyncStatus: string | null;
+  entryCount: number;
+}
+
+export interface ArchitectureEntrySummaryResponse {
+  id: string;
+  sourceId: string;
+  path: string;
+  category: string;
+  slug: string;
+  title: string;
+  syncedAt: string;
+}
+
+export const architectureApi = {
+  listSources: async (): Promise<ArchitectureSourceResponse[]> => {
+    const response = await makeRequest('/api/architecture/sources');
+    return handleApiResponse<ArchitectureSourceResponse[]>(response);
+  },
+
+  createSource: async (data: {
+    name: string;
+    owner: string;
+    repo: string;
+    branch?: string;
+    includePaths?: string[];
+  }): Promise<ArchitectureSourceResponse> => {
+    const response = await makeRequest('/api/architecture/sources', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+    return handleApiResponse<ArchitectureSourceResponse>(response);
+  },
+
+  updateSource: async (
+    sourceId: string,
+    data: {
+      name?: string;
+      branch?: string;
+      includePaths?: string[];
+      enabled?: boolean;
+    }
+  ): Promise<ArchitectureSourceResponse> => {
+    const response = await makeRequest(
+      `/api/architecture/sources/${sourceId}`,
+      { method: 'PUT', body: JSON.stringify(data) }
+    );
+    return handleApiResponse<ArchitectureSourceResponse>(response);
+  },
+
+  removeSource: async (sourceId: string): Promise<void> => {
+    const response = await makeRequest(
+      `/api/architecture/sources/${sourceId}`,
+      { method: 'DELETE' }
+    );
+    return handleApiResponse<void>(response);
+  },
+
+  syncSource: async (sourceId: string): Promise<ArchitectureSourceResponse> => {
+    const response = await makeRequest(
+      `/api/architecture/sources/${sourceId}/sync`,
+      { method: 'POST', body: JSON.stringify({}) }
+    );
+    return handleApiResponse<ArchitectureSourceResponse>(response);
+  },
+
+  listEntries: async (
+    sourceId?: string
+  ): Promise<ArchitectureEntrySummaryResponse[]> => {
+    const query = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+    const response = await makeRequest(`/api/architecture/entries${query}`);
+    return handleApiResponse<ArchitectureEntrySummaryResponse[]>(response);
   },
 };
 

--- a/frontend/src/pages/ui-new/settings/ArchitectureSettingsNew.tsx
+++ b/frontend/src/pages/ui-new/settings/ArchitectureSettingsNew.tsx
@@ -1,0 +1,390 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ArrowsClockwiseIcon,
+  PlusIcon,
+  TrashIcon,
+  SpinnerGapIcon,
+  CheckCircleIcon,
+  WarningIcon,
+} from '@phosphor-icons/react';
+
+import {
+  architectureApi,
+  makeRequest,
+  handleApiResponse,
+  type ArchitectureSourceResponse,
+} from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { SettingsCard } from '@/components/ui-new/primitives/SettingsCard';
+import { SettingsSection } from '@/components/ui-new/primitives/SettingsSection';
+import { SettingsToggle } from '@/components/ui-new/primitives/SettingsToggle';
+import { ErrorAlert } from '@/components/ui-new/primitives/ErrorAlert';
+import { PrimaryButton } from '@/components/ui-new/primitives/PrimaryButton';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui-new/primitives/Dialog';
+
+async function fetchSystemSettings(): Promise<Record<string, string>> {
+  const response = await makeRequest('/api/system-settings');
+  return handleApiResponse<Record<string, string>>(response);
+}
+
+async function saveGuidanceEnabled(enabled: boolean): Promise<void> {
+  const response = await makeRequest('/api/system-settings', {
+    method: 'PUT',
+    body: JSON.stringify({ architectureGuidanceEnabled: enabled }),
+  });
+  await handleApiResponse(response);
+}
+
+/** Missing setting means "on": the feature ships enabled by default. */
+function parseGuidanceEnabled(raw: string | undefined): boolean {
+  if (raw === undefined || raw.trim() === '') return true;
+  const v = raw.trim().toLowerCase();
+  return v === 'true' || v === '1';
+}
+
+interface NewSourceState {
+  name: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  includePaths: string;
+}
+
+const EMPTY_SOURCE: NewSourceState = {
+  name: '',
+  owner: '',
+  repo: '',
+  branch: 'main',
+  includePaths: 'templates/',
+};
+
+export function ArchitectureSettingsNew() {
+  const { t, i18n } = useTranslation(['settings', 'common']);
+
+  const [sources, setSources] = useState<ArchitectureSourceResponse[]>([]);
+  const [guidanceEnabled, setGuidanceEnabled] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [togglingGuidance, setTogglingGuidance] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [syncingId, setSyncingId] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  const [addState, setAddState] = useState<NewSourceState>(EMPTY_SOURCE);
+  const [addSaving, setAddSaving] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [list, settings] = await Promise.all([
+        architectureApi.listSources(),
+        fetchSystemSettings(),
+      ]);
+      setSources(list);
+      setGuidanceEnabled(
+        parseGuidanceEnabled(settings['architecture_guidance_enabled'])
+      );
+      setError(null);
+    } catch {
+      setError(t('settings.architecture.loadError'));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleToggleGuidance = async (enabled: boolean) => {
+    const previous = guidanceEnabled;
+    setGuidanceEnabled(enabled);
+    try {
+      setTogglingGuidance(true);
+      await saveGuidanceEnabled(enabled);
+    } catch {
+      setGuidanceEnabled(previous);
+      setError(t('settings.architecture.saveError'));
+    } finally {
+      setTogglingGuidance(false);
+    }
+  };
+
+  const handleToggleSource = async (
+    source: ArchitectureSourceResponse,
+    enabled: boolean
+  ) => {
+    try {
+      setBusyId(source.id);
+      await architectureApi.updateSource(source.id, { enabled });
+      await refresh();
+    } catch {
+      setError(t('settings.architecture.saveError'));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleSync = async (source: ArchitectureSourceResponse) => {
+    try {
+      setSyncingId(source.id);
+      await architectureApi.syncSource(source.id);
+      await refresh();
+    } catch {
+      setError(t('settings.architecture.syncError'));
+    } finally {
+      setSyncingId(null);
+    }
+  };
+
+  const handleDelete = async (source: ArchitectureSourceResponse) => {
+    try {
+      setBusyId(source.id);
+      await architectureApi.removeSource(source.id);
+      await refresh();
+    } catch {
+      setError(t('settings.architecture.deleteError'));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleAdd = async () => {
+    if (!addState.name.trim() || !addState.owner.trim() || !addState.repo.trim()) {
+      setAddError(t('settings.architecture.addDialog.requiredFields'));
+      return;
+    }
+    const includePaths = addState.includePaths
+      .split(',')
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+    try {
+      setAddSaving(true);
+      setAddError(null);
+      await architectureApi.createSource({
+        name: addState.name.trim(),
+        owner: addState.owner.trim(),
+        repo: addState.repo.trim(),
+        branch: addState.branch.trim() || undefined,
+        includePaths: includePaths.length > 0 ? includePaths : undefined,
+      });
+      setAddOpen(false);
+      setAddState(EMPTY_SOURCE);
+      await refresh();
+    } catch {
+      setAddError(t('settings.architecture.saveError'));
+    } finally {
+      setAddSaving(false);
+    }
+  };
+
+  const formatSyncTime = (iso: string | null) => {
+    if (!iso) return t('settings.architecture.source.neverSynced');
+    try {
+      return new Date(iso).toLocaleString(i18n.language);
+    } catch {
+      return iso;
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-double">
+        <SpinnerGapIcon className="size-icon-sm animate-spin text-low" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-double pb-16">
+      {error && <ErrorAlert message={error} />}
+
+      <SettingsSection title={t('settings.architecture.title')}>
+        <SettingsCard
+          title={t('settings.architecture.guidanceCard.title')}
+          description={t('settings.architecture.guidanceCard.description')}
+        >
+          <SettingsToggle
+            label={t('settings.architecture.guidanceCard.toggleLabel')}
+            description={t('settings.architecture.guidanceCard.toggleDescription')}
+            checked={guidanceEnabled}
+            disabled={togglingGuidance}
+            onChange={handleToggleGuidance}
+          />
+        </SettingsCard>
+
+        <SettingsCard
+          title={t('settings.architecture.sourcesCard.title')}
+          description={t('settings.architecture.sourcesCard.description')}
+        >
+          <div className="space-y-base">
+            {sources.map((source) => {
+              const syncOk = source.lastSyncStatus === 'ok';
+              return (
+                <div
+                  key={source.id}
+                  className="rounded border border-border bg-secondary p-base space-y-half"
+                >
+                  <div className="flex items-start justify-between gap-base">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-half flex-wrap">
+                        <span className="text-high text-base font-medium">
+                          {source.name}
+                        </span>
+                        {source.builtin && (
+                          <span className="rounded-full border border-brand/40 px-half text-xs uppercase tracking-wider text-brand">
+                            {t('settings.architecture.source.builtinBadge')}
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-low text-sm mt-0.5 font-ibm-plex-mono">
+                        {source.owner}/{source.repo}@{source.branch}
+                      </p>
+                      <p className="text-low text-xs">
+                        {t('settings.architecture.source.paths', {
+                          paths: source.includePaths.join(', '),
+                        })}
+                        {' · '}
+                        {t('settings.architecture.source.entryCount', {
+                          count: source.entryCount,
+                        })}
+                      </p>
+                      <p className="flex items-center gap-0.5 text-xs">
+                        {source.lastSyncStatus &&
+                          (syncOk ? (
+                            <CheckCircleIcon className="size-icon-xs text-success" />
+                          ) : (
+                            <WarningIcon className="size-icon-xs text-error" />
+                          ))}
+                        <span className={cn(syncOk ? 'text-low' : 'text-error')}>
+                          {source.lastSyncStatus
+                            ? t('settings.architecture.source.lastSync', {
+                                time: formatSyncTime(source.lastSyncedAt),
+                              })
+                            : t('settings.architecture.source.neverSynced')}
+                        </span>
+                      </p>
+                      {source.lastSyncStatus && !syncOk && (
+                        <p className="text-error text-xs break-all">
+                          {source.lastSyncStatus}
+                        </p>
+                      )}
+                    </div>
+                    <SettingsToggle
+                      label=""
+                      checked={source.enabled}
+                      disabled={busyId === source.id}
+                      onChange={(checked) => handleToggleSource(source, checked)}
+                      className="shrink-0 w-auto"
+                    />
+                  </div>
+
+                  <div className="flex items-center gap-half">
+                    <button
+                      type="button"
+                      onClick={() => handleSync(source)}
+                      disabled={syncingId === source.id}
+                      className="inline-flex items-center gap-0.5 rounded border border-border bg-panel px-half py-0.5 text-xs text-low hover:text-normal disabled:opacity-60"
+                    >
+                      <ArrowsClockwiseIcon
+                        className={cn(
+                          'size-icon-xs',
+                          syncingId === source.id && 'animate-spin'
+                        )}
+                      />
+                      {t('settings.architecture.actions.syncNow')}
+                    </button>
+                    {!source.builtin && (
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(source)}
+                        disabled={busyId === source.id}
+                        className="inline-flex items-center gap-0.5 rounded border border-border bg-panel px-half py-0.5 text-xs text-error hover:bg-error/10 disabled:opacity-60"
+                      >
+                        <TrashIcon className="size-icon-xs" />
+                        {t('settings.architecture.actions.delete')}
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="mt-base">
+            <PrimaryButton
+              actionIcon={PlusIcon}
+              value={t('settings.architecture.actions.addSource')}
+              onClick={() => {
+                setAddError(null);
+                setAddState(EMPTY_SOURCE);
+                setAddOpen(true);
+              }}
+            />
+          </div>
+        </SettingsCard>
+      </SettingsSection>
+
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('settings.architecture.addDialog.title')}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-base p-double pt-0">
+            {addError && <ErrorAlert message={addError} />}
+            {(
+              [
+                ['name', 'nameLabel', 'text'],
+                ['owner', 'ownerLabel', 'text'],
+                ['repo', 'repoLabel', 'text'],
+                ['branch', 'branchLabel', 'text'],
+                ['includePaths', 'includePathsLabel', 'text'],
+              ] as const
+            ).map(([field, labelKey]) => (
+              <div key={field} className="space-y-half">
+                <label
+                  className="text-normal text-sm"
+                  htmlFor={`arch-source-${field}`}
+                >
+                  {t(`settings.architecture.addDialog.${labelKey}`)}
+                </label>
+                <input
+                  id={`arch-source-${field}`}
+                  type="text"
+                  value={addState[field]}
+                  onChange={(e) =>
+                    setAddState((prev) => ({ ...prev, [field]: e.target.value }))
+                  }
+                  className="w-full rounded border border-border bg-secondary px-base py-1 text-base text-normal focus:outline-none focus:ring-1 focus:ring-brand"
+                />
+              </div>
+            ))}
+            <p className="text-low text-xs">
+              {t('settings.architecture.addDialog.includePathsHint')}
+            </p>
+            <div className="flex justify-end gap-half">
+              <PrimaryButton
+                variant="tertiary"
+                value={t('common:buttons.cancel')}
+                onClick={() => setAddOpen(false)}
+                disabled={addSaving}
+              />
+              <PrimaryButton
+                actionIcon={addSaving ? 'spinner' : undefined}
+                value={t('common:buttons.create')}
+                onClick={handleAdd}
+                disabled={addSaving}
+              />
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/ui-new/settings/DesignStylesSettingsNew.tsx
+++ b/frontend/src/pages/ui-new/settings/DesignStylesSettingsNew.tsx
@@ -1,0 +1,433 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  PlusIcon,
+  CopyIcon,
+  PencilSimpleIcon,
+  TrashIcon,
+  CaretDownIcon,
+  CaretUpIcon,
+  SpinnerGapIcon,
+} from '@phosphor-icons/react';
+
+import {
+  designStylesApi,
+  makeRequest,
+  handleApiResponse,
+  type DesignStyleResponse,
+} from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { SettingsCard } from '@/components/ui-new/primitives/SettingsCard';
+import { SettingsSection } from '@/components/ui-new/primitives/SettingsSection';
+import { SettingsSelect } from '@/components/ui-new/primitives/SettingsSelect';
+import { SettingsToggle } from '@/components/ui-new/primitives/SettingsToggle';
+import { ErrorAlert } from '@/components/ui-new/primitives/ErrorAlert';
+import { PrimaryButton } from '@/components/ui-new/primitives/PrimaryButton';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui-new/primitives/Dialog';
+
+async function fetchSystemSettings(): Promise<Record<string, string>> {
+  const response = await makeRequest('/api/system-settings');
+  return handleApiResponse<Record<string, string>>(response);
+}
+
+async function saveDefaultDesignStyle(slug: string): Promise<void> {
+  const response = await makeRequest('/api/system-settings', {
+    method: 'PUT',
+    body: JSON.stringify({ defaultDesignStyle: slug }),
+  });
+  await handleApiResponse(response);
+}
+
+interface StyleEditorState {
+  /** Style being edited, or null when creating a new one. */
+  editing: DesignStyleResponse | null;
+  name: string;
+  description: string;
+  content: string;
+}
+
+export function DesignStylesSettingsNew() {
+  const { t } = useTranslation(['settings', 'common']);
+
+  const [styles, setStyles] = useState<DesignStyleResponse[]>([]);
+  const [defaultSlug, setDefaultSlug] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [savingDefault, setSavingDefault] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [editor, setEditor] = useState<StyleEditorState | null>(null);
+  const [editorSaving, setEditorSaving] = useState(false);
+  const [editorError, setEditorError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [list, settings] = await Promise.all([
+        designStylesApi.list(),
+        fetchSystemSettings(),
+      ]);
+      setStyles(list);
+      setDefaultSlug(settings['default_design_style'] ?? '');
+      setError(null);
+    } catch {
+      setError(t('settings.designStyles.loadError'));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const enabledOptions = useMemo(() => {
+    const options = styles
+      .filter((s) => s.enabled)
+      .map((s) => ({ value: s.slug, label: s.name }));
+    return [
+      { value: '', label: t('settings.designStyles.defaultNone') },
+      ...options,
+    ];
+  }, [styles, t]);
+
+  const handleDefaultChange = async (slug: string) => {
+    const previous = defaultSlug;
+    setDefaultSlug(slug);
+    try {
+      setSavingDefault(true);
+      await saveDefaultDesignStyle(slug);
+    } catch {
+      setDefaultSlug(previous);
+      setError(t('settings.designStyles.saveError'));
+    } finally {
+      setSavingDefault(false);
+    }
+  };
+
+  const handleToggleEnabled = async (style: DesignStyleResponse, enabled: boolean) => {
+    try {
+      setBusyId(style.id);
+      await designStylesApi.update(style.id, { enabled });
+      await refresh();
+    } catch {
+      setError(t('settings.designStyles.saveError'));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleDelete = async (style: DesignStyleResponse) => {
+    try {
+      setBusyId(style.id);
+      await designStylesApi.remove(style.id);
+      await refresh();
+    } catch {
+      setError(t('settings.designStyles.deleteError'));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleDuplicate = async (style: DesignStyleResponse) => {
+    try {
+      setBusyId(style.id);
+      await designStylesApi.create({
+        name: t('settings.designStyles.copyName', { name: style.name }),
+        description: style.description,
+        content: style.content,
+      });
+      await refresh();
+    } catch {
+      setError(t('settings.designStyles.saveError'));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const openCreate = () => {
+    setEditorError(null);
+    setEditor({ editing: null, name: '', description: '', content: '' });
+  };
+
+  const openEdit = (style: DesignStyleResponse) => {
+    setEditorError(null);
+    setEditor({
+      editing: style,
+      name: style.name,
+      description: style.description,
+      content: style.content,
+    });
+  };
+
+  const handleEditorSave = async () => {
+    if (!editor) return;
+    if (!editor.name.trim() || !editor.content.trim()) {
+      setEditorError(t('settings.designStyles.editor.requiredFields'));
+      return;
+    }
+    try {
+      setEditorSaving(true);
+      setEditorError(null);
+      if (editor.editing) {
+        await designStylesApi.update(editor.editing.id, {
+          name: editor.name.trim(),
+          description: editor.description.trim(),
+          content: editor.content,
+        });
+      } else {
+        await designStylesApi.create({
+          name: editor.name.trim(),
+          description: editor.description.trim(),
+          content: editor.content,
+        });
+      }
+      setEditor(null);
+      await refresh();
+    } catch {
+      setEditorError(t('settings.designStyles.saveError'));
+    } finally {
+      setEditorSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-double">
+        <SpinnerGapIcon className="size-icon-sm animate-spin text-low" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-double pb-16">
+      {error && <ErrorAlert message={error} />}
+
+      <SettingsSection title={t('settings.designStyles.title')}>
+        <SettingsCard
+          title={t('settings.designStyles.defaultCard.title')}
+          description={t('settings.designStyles.defaultCard.description')}
+        >
+          <SettingsSelect
+            label={t('settings.designStyles.defaultCard.label')}
+            description={savingDefault ? t('common:states.saving') : undefined}
+            value={defaultSlug}
+            onChange={handleDefaultChange}
+            options={enabledOptions}
+          />
+        </SettingsCard>
+
+        <SettingsCard
+          title={t('settings.designStyles.listCard.title')}
+          description={t('settings.designStyles.listCard.description')}
+        >
+          <div className="space-y-base">
+            {styles.map((style) => (
+              <div
+                key={style.id}
+                className="rounded border border-border bg-secondary p-base space-y-half"
+              >
+                <div className="flex items-start justify-between gap-base">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-half flex-wrap">
+                      <span className="text-high text-base font-medium">
+                        {style.name}
+                      </span>
+                      <span
+                        className={cn(
+                          'rounded-full border px-half text-xs uppercase tracking-wider',
+                          style.builtin
+                            ? 'text-brand border-brand/40'
+                            : 'text-low border-border'
+                        )}
+                      >
+                        {style.builtin
+                          ? t('settings.designStyles.badge.builtin')
+                          : t('settings.designStyles.badge.custom')}
+                      </span>
+                      {style.license && (
+                        <span className="rounded-full border border-border px-half text-xs text-low">
+                          {style.license}
+                        </span>
+                      )}
+                    </div>
+                    {style.description && (
+                      <p className="text-low text-sm mt-0.5">{style.description}</p>
+                    )}
+                    {style.sourceName && style.sourceUrl && (
+                      <a
+                        href={style.sourceUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-low text-xs underline hover:text-normal"
+                      >
+                        {t('settings.designStyles.sourceLabel', {
+                          source: style.sourceName,
+                        })}
+                      </a>
+                    )}
+                  </div>
+                  <SettingsToggle
+                    label=""
+                    checked={style.enabled}
+                    disabled={busyId === style.id}
+                    onChange={(checked) => handleToggleEnabled(style, checked)}
+                    className="shrink-0 w-auto"
+                  />
+                </div>
+
+                <div className="flex items-center gap-half">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setExpandedId(expandedId === style.id ? null : style.id)
+                    }
+                    className="inline-flex items-center gap-0.5 rounded border border-border bg-panel px-half py-0.5 text-xs text-low hover:text-normal"
+                  >
+                    {expandedId === style.id ? (
+                      <CaretUpIcon className="size-icon-xs" />
+                    ) : (
+                      <CaretDownIcon className="size-icon-xs" />
+                    )}
+                    {t('settings.designStyles.actions.viewContent')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDuplicate(style)}
+                    disabled={busyId === style.id}
+                    className="inline-flex items-center gap-0.5 rounded border border-border bg-panel px-half py-0.5 text-xs text-low hover:text-normal disabled:opacity-60"
+                  >
+                    <CopyIcon className="size-icon-xs" />
+                    {t('settings.designStyles.actions.duplicate')}
+                  </button>
+                  {!style.builtin && (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => openEdit(style)}
+                        disabled={busyId === style.id}
+                        className="inline-flex items-center gap-0.5 rounded border border-border bg-panel px-half py-0.5 text-xs text-low hover:text-normal disabled:opacity-60"
+                      >
+                        <PencilSimpleIcon className="size-icon-xs" />
+                        {t('settings.designStyles.actions.edit')}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(style)}
+                        disabled={busyId === style.id}
+                        className="inline-flex items-center gap-0.5 rounded border border-border bg-panel px-half py-0.5 text-xs text-error hover:bg-error/10 disabled:opacity-60"
+                      >
+                        <TrashIcon className="size-icon-xs" />
+                        {t('settings.designStyles.actions.delete')}
+                      </button>
+                    </>
+                  )}
+                </div>
+
+                {expandedId === style.id && (
+                  <pre className="mt-half max-h-64 overflow-auto whitespace-pre-wrap rounded border border-border bg-primary p-base text-xs text-normal font-ibm-plex-mono">
+                    {style.content}
+                  </pre>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-base">
+            <PrimaryButton
+              actionIcon={PlusIcon}
+              value={t('settings.designStyles.actions.create')}
+              onClick={openCreate}
+            />
+          </div>
+        </SettingsCard>
+      </SettingsSection>
+
+      <Dialog open={editor !== null} onOpenChange={(open) => !open && setEditor(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>
+              {editor?.editing
+                ? t('settings.designStyles.editor.editTitle')
+                : t('settings.designStyles.editor.createTitle')}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-base p-double pt-0">
+            {editorError && <ErrorAlert message={editorError} />}
+            <div className="space-y-half">
+              <label className="text-normal text-sm" htmlFor="design-style-name">
+                {t('settings.designStyles.editor.nameLabel')}
+              </label>
+              <input
+                id="design-style-name"
+                type="text"
+                value={editor?.name ?? ''}
+                onChange={(e) =>
+                  setEditor((prev) => (prev ? { ...prev, name: e.target.value } : prev))
+                }
+                className="w-full rounded border border-border bg-secondary px-base py-1 text-base text-normal focus:outline-none focus:ring-1 focus:ring-brand"
+              />
+            </div>
+            <div className="space-y-half">
+              <label
+                className="text-normal text-sm"
+                htmlFor="design-style-description"
+              >
+                {t('settings.designStyles.editor.descriptionLabel')}
+              </label>
+              <input
+                id="design-style-description"
+                type="text"
+                value={editor?.description ?? ''}
+                onChange={(e) =>
+                  setEditor((prev) =>
+                    prev ? { ...prev, description: e.target.value } : prev
+                  )
+                }
+                className="w-full rounded border border-border bg-secondary px-base py-1 text-base text-normal focus:outline-none focus:ring-1 focus:ring-brand"
+              />
+            </div>
+            <div className="space-y-half">
+              <label className="text-normal text-sm" htmlFor="design-style-content">
+                {t('settings.designStyles.editor.contentLabel')}
+              </label>
+              <p className="text-low text-xs">
+                {t('settings.designStyles.editor.contentHint')}
+              </p>
+              <textarea
+                id="design-style-content"
+                value={editor?.content ?? ''}
+                onChange={(e) =>
+                  setEditor((prev) =>
+                    prev ? { ...prev, content: e.target.value } : prev
+                  )
+                }
+                rows={12}
+                className="w-full rounded border border-border bg-secondary px-base py-1 text-sm text-normal font-ibm-plex-mono focus:outline-none focus:ring-1 focus:ring-brand"
+              />
+            </div>
+            <div className="flex justify-end gap-half">
+              <PrimaryButton
+                variant="tertiary"
+                value={t('common:buttons.cancel')}
+                onClick={() => setEditor(null)}
+                disabled={editorSaving}
+              />
+              <PrimaryButton
+                actionIcon={editorSaving ? 'spinner' : undefined}
+                value={t('common:buttons.save')}
+                onClick={handleEditorSave}
+                disabled={editorSaving}
+              />
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/ui-new/settings/__tests__/ArchitectureSettingsNew.test.tsx
+++ b/frontend/src/pages/ui-new/settings/__tests__/ArchitectureSettingsNew.test.tsx
@@ -1,0 +1,97 @@
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const listSourcesMock = vi.fn();
+const syncSourceMock = vi.fn();
+const updateSourceMock = vi.fn();
+const removeSourceMock = vi.fn();
+const makeRequestMock = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  architectureApi: {
+    listSources: (...args: unknown[]) => listSourcesMock(...args),
+    createSource: vi.fn(),
+    updateSource: (...args: unknown[]) => updateSourceMock(...args),
+    removeSource: (...args: unknown[]) => removeSourceMock(...args),
+    syncSource: (...args: unknown[]) => syncSourceMock(...args),
+    listEntries: vi.fn(),
+  },
+  makeRequest: (...args: unknown[]) => makeRequestMock(...args),
+  handleApiResponse: async (value: unknown) => value,
+}));
+
+import { ArchitectureSettingsNew } from '../ArchitectureSettingsNew';
+import { renderWithI18n, setTestLanguage } from '@/test/renderWithI18n';
+
+const BUILTIN_SOURCE = {
+  id: 'src-1',
+  name: 'Awesome Architecture',
+  owner: 'study8677',
+  repo: 'awesome-architecture',
+  branch: 'main',
+  includePaths: ['templates/'],
+  enabled: true,
+  builtin: true,
+  lastSyncedAt: '2026-07-04T00:00:00Z',
+  lastSyncStatus: 'ok',
+  entryCount: 26,
+};
+
+describe('ArchitectureSettingsNew', () => {
+  beforeEach(async () => {
+    await setTestLanguage('en');
+    vi.clearAllMocks();
+    listSourcesMock.mockResolvedValue([BUILTIN_SOURCE]);
+    makeRequestMock.mockResolvedValue({});
+    syncSourceMock.mockResolvedValue(BUILTIN_SOURCE);
+    updateSourceMock.mockResolvedValue(BUILTIN_SOURCE);
+  });
+
+  it('renders the builtin source with coordinates and entry count', async () => {
+    renderWithI18n(<ArchitectureSettingsNew />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Awesome Architecture')).toBeInTheDocument()
+    );
+    expect(
+      screen.getByText('study8677/awesome-architecture@main')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/26 entries/)).toBeInTheDocument();
+    // Builtin sources cannot be deleted.
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+  });
+
+  it('defaults the guidance toggle to on when the setting is absent', async () => {
+    renderWithI18n(<ArchitectureSettingsNew />);
+    await waitFor(() =>
+      expect(screen.getByText('Awesome Architecture')).toBeInTheDocument()
+    );
+
+    const toggles = screen.getAllByRole('switch');
+    // First switch on the page is the guidance toggle.
+    expect(toggles[0]).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('respects a stored "false" guidance setting', async () => {
+    makeRequestMock.mockResolvedValue({
+      architecture_guidance_enabled: 'false',
+    });
+    renderWithI18n(<ArchitectureSettingsNew />);
+    await waitFor(() =>
+      expect(screen.getByText('Awesome Architecture')).toBeInTheDocument()
+    );
+
+    const toggles = screen.getAllByRole('switch');
+    expect(toggles[0]).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('triggers a manual sync', async () => {
+    renderWithI18n(<ArchitectureSettingsNew />);
+    await waitFor(() =>
+      expect(screen.getByText('Awesome Architecture')).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText('Sync now'));
+    await waitFor(() => expect(syncSourceMock).toHaveBeenCalledWith('src-1'));
+  });
+});

--- a/frontend/src/pages/ui-new/settings/__tests__/DesignStylesSettingsNew.test.tsx
+++ b/frontend/src/pages/ui-new/settings/__tests__/DesignStylesSettingsNew.test.tsx
@@ -1,0 +1,129 @@
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const listMock = vi.fn();
+const createMock = vi.fn();
+const updateMock = vi.fn();
+const removeMock = vi.fn();
+const makeRequestMock = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  designStylesApi: {
+    list: (...args: unknown[]) => listMock(...args),
+    create: (...args: unknown[]) => createMock(...args),
+    update: (...args: unknown[]) => updateMock(...args),
+    remove: (...args: unknown[]) => removeMock(...args),
+  },
+  makeRequest: (...args: unknown[]) => makeRequestMock(...args),
+  handleApiResponse: async (value: unknown) => value,
+}));
+
+import { DesignStylesSettingsNew } from '../DesignStylesSettingsNew';
+import { renderWithI18n, setTestLanguage } from '@/test/renderWithI18n';
+
+const BUILTIN_STYLE = {
+  id: 'style-1',
+  slug: 'anthropic-frontend-design',
+  name: 'Anthropic Frontend Design',
+  description: 'Distinctive production-grade UI direction.',
+  content: 'Approach this as the design lead...',
+  sourceName: 'anthropics/skills — frontend-design',
+  sourceUrl: 'https://github.com/anthropics/skills',
+  license: 'Apache-2.0',
+  builtin: true,
+  enabled: true,
+  createdAt: '2026-07-04T00:00:00Z',
+  updatedAt: '2026-07-04T00:00:00Z',
+};
+
+const CUSTOM_STYLE = {
+  id: 'style-2',
+  slug: 'my-style',
+  name: 'My Style',
+  description: 'Personal direction.',
+  content: 'Use warm monochrome.',
+  sourceName: null,
+  sourceUrl: null,
+  license: null,
+  builtin: false,
+  enabled: true,
+  createdAt: '2026-07-04T00:00:00Z',
+  updatedAt: '2026-07-04T00:00:00Z',
+};
+
+describe('DesignStylesSettingsNew', () => {
+  beforeEach(async () => {
+    await setTestLanguage('en');
+    vi.clearAllMocks();
+    listMock.mockResolvedValue([BUILTIN_STYLE, CUSTOM_STYLE]);
+    // System settings GET (default style not set).
+    makeRequestMock.mockResolvedValue({ default_design_style: '' });
+    updateMock.mockResolvedValue(CUSTOM_STYLE);
+    createMock.mockResolvedValue(CUSTOM_STYLE);
+    removeMock.mockResolvedValue(undefined);
+  });
+
+  it('renders builtin and custom styles with their badges and attribution', async () => {
+    renderWithI18n(<DesignStylesSettingsNew />);
+
+    // Style names appear both as default-style <option>s and as card titles.
+    await waitFor(() =>
+      expect(
+        screen.getAllByText('Anthropic Frontend Design').length
+      ).toBeGreaterThan(0)
+    );
+    expect(screen.getAllByText('My Style').length).toBeGreaterThan(0);
+    expect(screen.getByText('None (no design direction)')).toBeInTheDocument();
+    expect(screen.getByText('Built-in')).toBeInTheDocument();
+    expect(screen.getByText('Custom')).toBeInTheDocument();
+    expect(screen.getByText('Apache-2.0')).toBeInTheDocument();
+    expect(
+      screen.getByText('Source: anthropics/skills — frontend-design')
+    ).toBeInTheDocument();
+  });
+
+  it('only offers edit/delete for custom styles', async () => {
+    renderWithI18n(<DesignStylesSettingsNew />);
+    await waitFor(() =>
+      expect(screen.getAllByText('My Style').length).toBeGreaterThan(0)
+    );
+
+    // One custom style → exactly one Edit and one Delete action.
+    expect(screen.getAllByText('Edit')).toHaveLength(1);
+    expect(screen.getAllByText('Delete')).toHaveLength(1);
+    // Both styles can be duplicated.
+    expect(screen.getAllByText('Duplicate')).toHaveLength(2);
+  });
+
+  it('duplicates a builtin style into a custom copy', async () => {
+    renderWithI18n(<DesignStylesSettingsNew />);
+    await waitFor(() =>
+      expect(
+        screen.getAllByText('Anthropic Frontend Design').length
+      ).toBeGreaterThan(0)
+    );
+
+    fireEvent.click(screen.getAllByText('Duplicate')[0]);
+
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Anthropic Frontend Design (copy)',
+        content: BUILTIN_STYLE.content,
+      })
+    );
+  });
+
+  it('expands style content on demand', async () => {
+    renderWithI18n(<DesignStylesSettingsNew />);
+    await waitFor(() =>
+      expect(screen.getAllByText('My Style').length).toBeGreaterThan(0)
+    );
+
+    expect(
+      screen.queryByText('Use warm monochrome.')
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByText('View content')[1]);
+    expect(screen.getByText('Use warm monochrome.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ui-new/settings/index.ts
+++ b/frontend/src/pages/ui-new/settings/index.ts
@@ -8,3 +8,5 @@ export { FeishuSettingsNew } from './FeishuSettingsNew';
 export { OrganizationSettingsNew } from './OrganizationSettingsNew';
 export { RuntimeSettingsNew } from './RuntimeSettingsNew';
 export { QualityGateSettingsNew } from './QualityGateSettingsNew';
+export { ArchitectureSettingsNew } from './ArchitectureSettingsNew';
+export { DesignStylesSettingsNew } from './DesignStylesSettingsNew';


### PR DESCRIPTION
## Summary | 摘要

Two additions that shape how the orchestrated workspace plans and builds, plus a full licensing pass for everything the project incorporates.

为编排工作区新增两项影响"怎么规划、怎么做"的能力，并对项目引入的全部上游内容补全许可证署名。

### 1. Architecture-aware planning | 架构感知规划

- New tables `architecture_source` / `architecture_entry`; builtin knowledge source [study8677/awesome-architecture](https://github.com/study8677/awesome-architecture) (MIT), user-extensible (any GitHub repo, path-prefix filtered markdown) via REST + Settings → Architecture Knowledge.
- GitHub trees-API sync with blob-SHA incremental fetching and tree-SHA short-circuit; background check every 6 h, refresh when > 24 h stale; optional `SOLODAWN_GITHUB_TOKEN` / `GITHUB_TOKEN`.
- Digest extraction targets the highest-value template sections (关键决策/权衡/规模化/瓶颈/误区/反模式 + English equivalents); keyword extraction picks slug tokens, title, and Latin product names (verified live: dify, coze, langgraph, claude, stripe…).
- At draft materialization, a `## Architecture Guidance` section (self-answered methodology checklist adapted from [study8677/architecture-copilot](https://github.com/study8677/architecture-copilot), MIT + top-2 matched digests, min score 3) is appended into `initial_goal` — the exact requirement-ledger precedent; fail-open at every step.
- 新表 `architecture_source` / `architecture_entry`；内置知识源 awesome-architecture（MIT），用户可通过 REST 与系统设置自行扩展；trees API 增量同步（blob-SHA 差量 + tree-SHA 短路），后台每 6 小时检查、超 24 小时自动刷新；物化时把"架构指引"（自答式方法论清单 + 匹配到的模板摘要）注入 `initial_goal`，全链路 fail-open。

### 2. Design styles | 设计风格

- New table `design_style`; 6 builtin presets condensed from high-rated open-source design skills, seeded at startup with refresh-on-upgrade that preserves the user's enabled/disabled choice; full custom-style CRUD (builtin = read-only + duplicate).
- Per-round picker in the workspace conversation toolbar (`planning_draft.design_style_slug` + `PUT /planning-drafts/{id}/design-style`), system default in Settings → Design Styles.
- At materialization the style renders as a `## Design Direction` section; the runtime orchestrator contract ("Goal Context Sections") requires carrying it into every UI-related terminal instruction, including the greenfield foundation task.
- 新表 `design_style`；6 套内置预设开机播种、升级刷新且保留用户启用状态；工作区工具栏按轮选择 + 系统默认；物化时以"设计方向"段落注入，编排器契约要求带入所有 UI 相关终端指令（含地基任务）。

| Preset | Adapted from | License |
|---|---|---|
| Anthropic Frontend Design | anthropics/skills — frontend-design | Apache-2.0 |
| Minimalist Editorial / Industrial Brutalist / Soft Premium | Leonxlnx/taste-skill | MIT |
| Impeccable Design Language | pbakaus/impeccable | Apache-2.0 |
| Emil Design Engineering | emilkowalski/skills | MIT |

### 3. Licensing | 许可证

- LICENSE gains sections 5–7: shadcn/ui (MIT), design style presets (verbatim upstream copyright notices; Apache-2.0 changes marked per §4(b) in each asset header), architecture methodology & runtime-synced knowledge sources; summary table updated.
- Every seeded asset file carries an attribution header (source, license, changes, date).
- LICENSE 新增第 5–7 节（shadcn/ui、设计风格预设、架构方法论与知识源），逐字保留上游版权声明，Apache-2.0 的修改按 §4(b) 在文件头标注；摘要表同步更新。

### Docs & i18n | 文档与国际化

- Bilingual README: feature bullets + new deep-dive section "Architecture Knowledge & Design Styles" + workspace guide step-3 pointer + license list.
- All 6 locales (en/es/ja/ko/zh-Hans/zh-Hant) for both settings pages, nav items, and the workspace style dropdown.

## Verification | 验证

- Backend: `cargo build --workspace --exclude solodawn-tray --profile ci --tests` ✅ · clippy `--all-targets --all-features -D warnings` ✅ (pipefail-verified exit 0) · `cargo nextest run --lib`: **1133/1133 passed** (13 new unit tests: sync path filtering, digest/keyword/title extraction, matching ranks zh+en, attribution stripping, builtin re-seed preserves disabled, prompt contract) · `generate_types --check` ✅
- Frontend: vitest **523/523 passed** (8 new component tests) · eslint ✅ · tsc ✅ · lint:i18n adds no new warnings from touched files
- Live functional test against a real isolated server (`target/ci/server.exe`, temp asset dir, port 39461): builtin seeding, **real GitHub sync fetched 27 templates** (upstream added one since research — sync design proven against a moving repo), all 27 digests 785–1249 B in DB, keyword extraction verified, settings round-trip, style CRUD + builtin guards (content edit 400 / delete 400 / enabled-only 200), draft creation with style slug, style update endpoint validation (invalid slug 400) — **15/15 checks passed**; temp env deleted afterwards.
- 后端与前端全部按 CI 同款命令本地跑绿；另起隔离真实服务器做了全功能实测（真实 GitHub 同步拉到 27 个模板，摘要/关键词落库验证，全部 REST 守卫行为符合预期），测试环境已清理。

## Notes for review | 评审提示

- No workflow-table schema change: both sections ride inside `initial_goal` (requirement-ledger precedent).
- `system-settings` PUT now takes camelCase (with `feishu_enabled` alias kept for back-compat).
- Missing `architecture_guidance_enabled` setting means **on** (dedicated helper, not `get_bool`'s default-false).
- Synced knowledge content is stored in the user's local DB only, never redistributed with releases.
