### PR TITLE
fix(dev): Windows dev startup; feat(models): official/compatible model UX & catalog refresh

### DIFF
--- a/frontend/src/components/setup/SetupWizardStep2Model.tsx
+++ b/frontend/src/components/setup/SetupWizardStep2Model.tsx
@@ -6,13 +6,13 @@ import {
   CircleNotchIcon,
   EyeIcon,
   EyeSlashIcon,
-  CaretDownIcon,
   LightningIcon,
   KeyIcon,
 } from '@phosphor-icons/react';
 
 import { cn } from '@/lib/utils';
 import { CLI_TYPES } from '@/components/workflow/constants';
+import { isCompatibleApiType } from '@/components/workflow/modelCatalog';
 import type { SetupModelMode } from './SetupWizardStep2ModelContainer';
 
 const API_TYPE_OPTIONS = [
@@ -382,30 +382,33 @@ export function SetupWizardStep2Model({
             </div>
           )}
 
-          {/* Fetch Models + Model Dropdown */}
-          <div className="space-y-half">
-            <button
-              type="button"
-              onClick={onFetchModels}
-              disabled={isLoadingModels || !apiKey.trim()}
-              className={cn(
-                'flex items-center justify-center gap-half w-full',
-                'px-base py-base rounded border border-border text-base',
-                'bg-secondary text-normal transition-colors',
-                'hover:border-brand hover:text-high',
-                'disabled:opacity-50 disabled:cursor-not-allowed'
-              )}
-            >
-              {isLoadingModels && (
-                <CircleNotchIcon className="size-icon-sm animate-spin" weight="bold" />
-              )}
-              {isLoadingModels
-                ? t('setup:wizard.model.fetchingModels')
-                : t('setup:wizard.model.fetchModelsButton')}
-            </button>
-          </div>
+          {/* Fetch Models — only compatible endpoints need a live list;
+              official APIs use the built-in catalog. */}
+          {isCompatibleApiType(apiType) && (
+            <div className="space-y-half">
+              <button
+                type="button"
+                onClick={onFetchModels}
+                disabled={isLoadingModels || !apiKey.trim() || !baseUrl.trim()}
+                className={cn(
+                  'flex items-center justify-center gap-half w-full',
+                  'px-base py-base rounded border border-border text-base',
+                  'bg-secondary text-normal transition-colors',
+                  'hover:border-brand hover:text-high',
+                  'disabled:opacity-50 disabled:cursor-not-allowed'
+                )}
+              >
+                {isLoadingModels && (
+                  <CircleNotchIcon className="size-icon-sm animate-spin" weight="bold" />
+                )}
+                {isLoadingModels
+                  ? t('setup:wizard.model.fetchingModels')
+                  : t('setup:wizard.model.fetchModelsButton')}
+              </button>
+            </div>
+          )}
 
-          {/* Model Selector (dropdown if models fetched, manual input otherwise) */}
+          {/* Model ID: free input with catalog/fetched suggestions */}
           <div className="space-y-half">
             <label
               htmlFor="setup-model-id"
@@ -413,47 +416,32 @@ export function SetupWizardStep2Model({
             >
               {t('setup:wizard.model.modelIdLabel')}
             </label>
-            {models.length > 0 ? (
-              <div className="relative">
-                <select
-                  id="setup-model-id"
-                  value={modelId}
-                  onChange={(e) => onModelIdChange(e.target.value)}
-                  className={cn(
-                    'w-full appearance-none rounded border border-border bg-secondary',
-                    'px-base py-base pr-8 text-base text-normal',
-                    'focus:outline-none focus:ring-1 focus:ring-brand'
-                  )}
-                >
-                  <option key="empty" value="">
-                    {t('setup:wizard.model.modelIdPlaceholder')}
-                  </option>
-                  {models.map((m) => (
-                    <option key={m.id} value={m.id}>
-                      {m.name}
-                    </option>
-                  ))}
-                </select>
-                <CaretDownIcon
-                  className="size-icon-xs absolute right-2 top-1/2 -translate-y-1/2 text-low pointer-events-none"
-                  weight="bold"
-                />
-              </div>
-            ) : (
-              <input
-                id="setup-model-id"
-                type="text"
-                value={modelId}
-                onChange={(e) => onModelIdChange(e.target.value)}
-                placeholder={t('setup:wizard.model.modelIdManualPlaceholder', { defaultValue: t('setup:wizard.model.modelIdPlaceholder') })}
-                className={cn(
-                  'w-full rounded border border-border bg-secondary',
-                  'px-base py-base text-base text-normal',
-                  'placeholder:text-low placeholder:opacity-80',
-                  'focus:outline-none focus:ring-1 focus:ring-brand'
-                )}
-              />
-            )}
+            <input
+              id="setup-model-id"
+              type="text"
+              list="setup-model-id-options"
+              value={modelId}
+              onChange={(e) => onModelIdChange(e.target.value)}
+              placeholder={t('setup:wizard.model.modelIdManualPlaceholder', { defaultValue: t('setup:wizard.model.modelIdPlaceholder') })}
+              className={cn(
+                'w-full rounded border border-border bg-secondary',
+                'px-base py-base text-base text-normal',
+                'placeholder:text-low placeholder:opacity-80',
+                'focus:outline-none focus:ring-1 focus:ring-brand'
+              )}
+            />
+            <datalist id="setup-model-id-options">
+              {models.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name}
+                </option>
+              ))}
+            </datalist>
+            <p className="text-sm text-low">
+              {isCompatibleApiType(apiType)
+                ? t('setup:wizard.model.compatibleModelsHint')
+                : t('setup:wizard.model.officialModelsHint')}
+            </p>
           </div>
 
           {/* Verify Connection */}

--- a/frontend/src/components/setup/SetupWizardStep2ModelContainer.tsx
+++ b/frontend/src/components/setup/SetupWizardStep2ModelContainer.tsx
@@ -6,6 +6,10 @@ import { useUserSystem } from '@/components/ConfigProvider';
 import { useModelVerification } from '@/hooks/useModelVerification';
 import { useNativeCredentials } from '@/hooks/useNativeCredentials';
 import { setDefaultModelForCli } from '@/hooks/useCliTypes';
+import {
+  OFFICIAL_MODELS,
+  isCompatibleApiType,
+} from '@/components/workflow/modelCatalog';
 import type { ApiType, ModelConfig } from '@/components/workflow/types';
 import {
   createNativeModelConfigs,
@@ -71,6 +75,19 @@ export function SetupWizardStep2ModelContainer({
     verifyModel,
     reset: resetVerification,
   } = useModelVerification();
+
+  // Official APIs suggest the built-in catalog; compatible endpoints suggest
+  // whatever the live fetch returned (empty until fetched).
+  const modelOptions = useMemo(
+    () =>
+      isCompatibleApiType(apiType)
+        ? models
+        : (OFFICIAL_MODELS[apiType as ApiType] ?? []).map((m) => ({
+            id: m,
+            name: m,
+          })),
+    [apiType, models]
+  );
 
   // Allow proceeding if model ID is manually entered, even without verification.
   // Third-party OpenAI-compatible endpoints may not support the verification API.
@@ -237,7 +254,7 @@ export function SetupWizardStep2ModelContainer({
       apiKey={apiKey}
       baseUrl={baseUrl}
       modelId={modelId}
-      models={models}
+      models={modelOptions}
       isLoadingModels={isLoadingModels}
       isVerified={isVerified}
       verifyError={verifyError}

--- a/frontend/src/components/workflow/modelCatalog.ts
+++ b/frontend/src/components/workflow/modelCatalog.ts
@@ -1,0 +1,51 @@
+import type { ApiType } from './types';
+
+/**
+ * Built-in model catalogs for the official provider APIs.
+ *
+ * Single source of truth for every model dropdown/suggestion list in the app
+ * (setup wizard, workflow wizard, model store). Compatible endpoints have no
+ * fixed catalog — their models live behind the relay and are fetched live via
+ * `/api/models/list` instead.
+ *
+ * Catalog refreshed 2026-07-05 against the providers' official model docs.
+ */
+export const OFFICIAL_MODELS: Record<ApiType, readonly string[]> = {
+  anthropic: [
+    'claude-fable-5',
+    'claude-opus-4-8',
+    'claude-sonnet-5',
+    'claude-haiku-4-5',
+    'claude-opus-4-7',
+    'claude-opus-4-6',
+    'claude-sonnet-4-6',
+  ],
+  'anthropic-compatible': [],
+  google: [
+    'gemini-3.5-flash',
+    'gemini-3.1-pro-preview',
+    'gemini-3.1-flash-lite',
+    'gemini-3-flash-preview',
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
+  ],
+  openai: [
+    'gpt-5.5',
+    'gpt-5.4',
+    'gpt-5.4-mini',
+    'gpt-5.4-nano',
+    'gpt-5.2',
+    'gpt-5.1',
+  ],
+  'openai-compatible': [],
+};
+
+/**
+ * Compatible types point at user-supplied base URLs (relays/proxies), so the
+ * served model list is unknowable ahead of time — these are the only types
+ * where fetching the live model list makes sense. Official APIs use
+ * {@link OFFICIAL_MODELS} directly.
+ */
+export function isCompatibleApiType(apiType: string): boolean {
+  return apiType === 'anthropic-compatible' || apiType === 'openai-compatible';
+}

--- a/frontend/src/components/workflow/steps/Step3Models.test.tsx
+++ b/frontend/src/components/workflow/steps/Step3Models.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { Step3Models } from './Step3Models';
+import { OFFICIAL_MODELS } from '../modelCatalog';
 import type { WizardConfig } from '../types';
 import { renderWithI18n, setTestLanguage, i18n } from '@/test/renderWithI18n';
 
@@ -370,7 +371,7 @@ describe('Step3Models', () => {
     expect(screen.getByText('GPT-4')).toBeInTheDocument();
   });
 
-  it('should show fetch models button', () => {
+  it('should hide fetch models button for official API types', () => {
     renderWithI18n(
       <Step3Models
         config={defaultConfig}
@@ -380,6 +381,22 @@ describe('Step3Models', () => {
 
     const addButton = screen.getByRole('button', { name: i18n.t('workflow:step3.addModel') });
     fireEvent.click(addButton);
+
+    // Default apiType is the official "anthropic" — no live fetch needed.
+    expect(screen.queryByRole('button', { name: i18n.t('workflow:step3.actions.fetchModels') })).not.toBeInTheDocument();
+  });
+
+  it('should show fetch models button for compatible API types', () => {
+    renderWithI18n(
+      <Step3Models
+        config={defaultConfig}
+        onUpdate={mockOnUpdate}
+      />
+    );
+
+    const addButton = screen.getByRole('button', { name: i18n.t('workflow:step3.addModel') });
+    fireEvent.click(addButton);
+    fireEvent.click(screen.getByText('Anthropic Compatible'));
 
     expect(screen.getByRole('button', { name: i18n.t('workflow:step3.actions.fetchModels') })).toBeInTheDocument();
   });
@@ -398,7 +415,7 @@ describe('Step3Models', () => {
     expect(screen.getByRole('button', { name: i18n.t('workflow:step3.actions.verify') })).toBeInTheDocument();
   });
 
-  it('should display model selection dropdown when models are fetched', async () => {
+  it('should suggest built-in models for official API types without fetching', () => {
     renderWithI18n(
       <Step3Models
         config={defaultConfig}
@@ -409,18 +426,48 @@ describe('Step3Models', () => {
     const addButton = screen.getByRole('button', { name: i18n.t('workflow:step3.addModel') });
     fireEvent.click(addButton);
 
-    // Fill in API Key
+    const modelInput = screen.getByLabelText(i18n.t('workflow:step3.fields.modelId.label'));
+    expect(modelInput.tagName).toBe('INPUT');
+    expect(modelInput).toHaveAttribute('list', 'modelId-options');
+
+    const options = Array.from(
+      document.querySelectorAll('#modelId-options option')
+    ).map((o) => (o as HTMLOptionElement).value);
+    expect(options).toEqual([...OFFICIAL_MODELS.anthropic]);
+  });
+
+  it('should fetch models into suggestions for compatible endpoints', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ models: ['glm-5', 'glm-4.5'] }),
+    } as Response);
+
+    renderWithI18n(
+      <Step3Models
+        config={defaultConfig}
+        onUpdate={mockOnUpdate}
+      />
+    );
+
+    const addButton = screen.getByRole('button', { name: i18n.t('workflow:step3.addModel') });
+    fireEvent.click(addButton);
+    fireEvent.click(screen.getByText('Anthropic Compatible'));
+
+    fireEvent.change(screen.getByLabelText(i18n.t('workflow:step3.fields.baseUrl.label')), { target: { value: 'https://relay.example.com' } });
     fireEvent.change(screen.getByLabelText(i18n.t('workflow:step3.fields.apiKey.label')), { target: { value: 'sk-test-key' } });
 
-    // Click fetch models
     const fetchButton = screen.getByRole('button', { name: i18n.t('workflow:step3.actions.fetchModels') });
     fireEvent.click(fetchButton);
 
-    // After fetching, model selection should be available (dropdown with options)
     await waitFor(() => {
-      const modelIdSelect = screen.getByLabelText(i18n.t('workflow:step3.fields.modelId.label'));
-      expect(modelIdSelect).toBeInTheDocument();
-      expect(modelIdSelect.tagName).toBe('SELECT');
+      const options = Array.from(
+        document.querySelectorAll('#modelId-options option')
+      ).map((o) => (o as HTMLOptionElement).value);
+      expect(options).toEqual(['glm-5', 'glm-4.5']);
     });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/models/list?'),
+      expect.objectContaining({ headers: { 'X-API-Key': 'sk-test-key' } })
+    );
   });
 });

--- a/frontend/src/components/workflow/steps/Step3Models.tsx
+++ b/frontend/src/components/workflow/steps/Step3Models.tsx
@@ -23,6 +23,7 @@ import {
 import { IconButton } from '../../ui-new/primitives/IconButton';
 import { cn } from '@/lib/utils';
 import { CLI_TYPES } from '../constants';
+import { OFFICIAL_MODELS, isCompatibleApiType } from '../modelCatalog';
 import type { WizardConfig, ModelConfig, ApiType } from '../types';
 import {
   createNativeModelConfigs,
@@ -44,27 +45,27 @@ const API_TYPES = {
   anthropic: {
     label: 'Anthropic',
     defaultBaseUrl: 'https://api.anthropic.com',
-    defaultModels: ['claude-opus-4-8', 'claude-sonnet-5', 'claude-haiku-4-5'],
+    defaultModels: OFFICIAL_MODELS.anthropic,
   },
   'anthropic-compatible': {
     label: 'Anthropic Compatible',
     defaultBaseUrl: '',
-    defaultModels: [],
+    defaultModels: OFFICIAL_MODELS['anthropic-compatible'],
   },
   google: {
     label: 'Google',
     defaultBaseUrl: 'https://generativelanguage.googleapis.com',
-    defaultModels: ['gemini-2.0-flash-exp', 'gemini-1.5-pro'],
+    defaultModels: OFFICIAL_MODELS.google,
   },
   openai: {
     label: 'OpenAI',
     defaultBaseUrl: 'https://api.openai.com',
-    defaultModels: ['gpt-4', 'gpt-4-turbo', 'gpt-3.5-turbo'],
+    defaultModels: OFFICIAL_MODELS.openai,
   },
   'openai-compatible': {
     label: 'OpenAI Compatible',
     defaultBaseUrl: '',
-    defaultModels: [],
+    defaultModels: OFFICIAL_MODELS['openai-compatible'],
   },
 } as const;
 
@@ -151,7 +152,7 @@ export const Step3Models: React.FC<Step3ModelsProps> = ({
       apiKey: '',
       modelId: '',
     });
-    setAvailableModels([]);
+    setAvailableModels([...API_TYPES.anthropic.defaultModels]);
     setFormErrors({});
     setIsFormVerified(false);
     setIsDialogOpen(true);
@@ -674,69 +675,60 @@ export const Step3Models: React.FC<Step3ModelsProps> = ({
               {formErrors.apiKey && <FieldError>{formErrors.apiKey}</FieldError>}
             </Field>
 
-            {/* Fetch Models Button */}
-            <Field>
-              <button
-                type="button"
-                onClick={() => {
-                  void handleFetchModels();
-                }}
-                disabled={isFetching || !formData.apiKey}
-                className={cn(
-                  'flex items-center justify-center gap-half w-full px-base py-half rounded-sm border text-base',
-                  'hover:border-brand hover:text-high transition-colors',
-                  'disabled:opacity-50 disabled:cursor-not-allowed',
-                  'bg-secondary text-normal'
-                )}
-              >
-                {isFetching && <ArrowsClockwiseIcon className="size-icon-sm animate-spin" />}
-                {isFetching ? t('step3.actions.fetching') : t('step3.actions.fetchModels')}
-              </button>
-              {formErrors.fetch && <FieldError>{formErrors.fetch}</FieldError>}
-            </Field>
-
-            {/* Model Selection/Input */}
-            <Field>
-              <FieldLabel htmlFor="modelId">{t('step3.fields.modelId.label')}</FieldLabel>
-              {availableModels.length > 0 ? (
-                <select
-                  id="modelId"
-                  value={formData.modelId}
-                  onChange={(e) => {
-                    setFormData({ ...formData, modelId: e.target.value });
-                    setIsFormVerified(false);
+            {/* Fetch Models Button — only compatible endpoints need a live
+                list; official APIs use the built-in catalog. */}
+            {isCompatibleApiType(formData.apiType) && (
+              <Field>
+                <button
+                  type="button"
+                  onClick={() => {
+                    void handleFetchModels();
                   }}
+                  disabled={isFetching || !formData.apiKey || !formData.baseUrl.trim()}
                   className={cn(
-                    'w-full bg-secondary rounded-sm border px-base py-half text-base text-high',
-                    'focus:outline-none focus:ring-1 focus:ring-brand',
-                    formErrors.modelId && 'border-error'
+                    'flex items-center justify-center gap-half w-full px-base py-half rounded-sm border text-base',
+                    'hover:border-brand hover:text-high transition-colors',
+                    'disabled:opacity-50 disabled:cursor-not-allowed',
+                    'bg-secondary text-normal'
                   )}
                 >
-                  <option value="">{t('step3.fields.modelId.selectPlaceholder')}</option>
-                  {availableModels.map((model) => (
-                    <option key={model} value={model}>
-                      {model}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <input
-                  id="modelId"
-                  type="text"
-                  value={formData.modelId}
-                  onChange={(e) => {
-                    setFormData({ ...formData, modelId: e.target.value });
-                    setIsFormVerified(false);
-                  }}
-                  placeholder={t('step3.fields.modelId.placeholder')}
-                  className={cn(
-                    'w-full bg-secondary rounded-sm border px-base py-half text-base text-high',
-                    'placeholder:text-low placeholder:opacity-80',
-                    'focus:outline-none focus:ring-1 focus:ring-brand',
-                    formErrors.modelId && 'border-error'
-                  )}
-                />
-              )}
+                  {isFetching && <ArrowsClockwiseIcon className="size-icon-sm animate-spin" />}
+                  {isFetching ? t('step3.actions.fetching') : t('step3.actions.fetchModels')}
+                </button>
+                {formErrors.fetch && <FieldError>{formErrors.fetch}</FieldError>}
+              </Field>
+            )}
+
+            {/* Model ID: free input with catalog/fetched suggestions */}
+            <Field>
+              <FieldLabel htmlFor="modelId">{t('step3.fields.modelId.label')}</FieldLabel>
+              <input
+                id="modelId"
+                type="text"
+                list="modelId-options"
+                value={formData.modelId}
+                onChange={(e) => {
+                  setFormData({ ...formData, modelId: e.target.value });
+                  setIsFormVerified(false);
+                }}
+                placeholder={t('step3.fields.modelId.placeholder')}
+                className={cn(
+                  'w-full bg-secondary rounded-sm border px-base py-half text-base text-high',
+                  'placeholder:text-low placeholder:opacity-80',
+                  'focus:outline-none focus:ring-1 focus:ring-brand',
+                  formErrors.modelId && 'border-error'
+                )}
+              />
+              <datalist id="modelId-options">
+                {availableModels.map((model) => (
+                  <option key={model} value={model} />
+                ))}
+              </datalist>
+              <p className="text-xs text-low mt-half">
+                {isCompatibleApiType(formData.apiType)
+                  ? t('step3.hints.compatibleModels')
+                  : t('step3.hints.officialModels')}
+              </p>
               {formErrors.modelId && <FieldError>{formErrors.modelId}</FieldError>}
             </Field>
 

--- a/frontend/src/hooks/useModelVerification.ts
+++ b/frontend/src/hooks/useModelVerification.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import type { ApiType } from '@/components/workflow/types';
+import { OFFICIAL_MODELS } from '@/components/workflow/modelCatalog';
 
 interface ModelEntry {
   id: string;
@@ -21,20 +22,6 @@ export interface UseModelVerificationResult {
   }) => Promise<boolean>;
   reset: () => void;
 }
-
-const DEFAULT_MODELS: Record<ApiType, string[]> = {
-  anthropic: [
-    'claude-opus-4-8',
-    'claude-sonnet-5',
-    'claude-haiku-4-5',
-    'claude-opus-4-7',
-    'claude-sonnet-4-6',
-  ],
-  'anthropic-compatible': [],
-  google: ['gemini-2.0-flash-exp', 'gemini-1.5-pro', 'gemini-1.5-flash'],
-  openai: ['gpt-4o', 'gpt-4-turbo', 'gpt-4', 'gpt-3.5-turbo'],
-  'openai-compatible': [],
-};
 
 /**
  * Reusable hook for model fetching and verification.
@@ -73,8 +60,8 @@ export function useModelVerification(): UseModelVerificationResult {
         }));
         setModels(fetched);
       } catch (_err) {
-        // Fall back to default models for the provider
-        const defaults = DEFAULT_MODELS[apiType as ApiType] ?? [];
+        // Fall back to the built-in models for the provider
+        const defaults = OFFICIAL_MODELS[apiType as ApiType] ?? [];
         setModels(defaults.map((m) => ({ id: m, name: m })));
         setVerifyError(
           _err instanceof Error ? _err.message : 'Failed to fetch models'

--- a/frontend/src/i18n/locales/en/setup.json
+++ b/frontend/src/i18n/locales/en/setup.json
@@ -53,7 +53,9 @@
         "openai": "OpenAI",
         "google": "Google AI",
         "openaiCompatible": "OpenAI Compatible"
-      }
+      },
+      "officialModelsHint": "Official API: built-in model list is suggested — you can also type any model ID.",
+      "compatibleModelsHint": "Compatible endpoint: fetch the model list from the endpoint, or type the model ID manually."
     },
     "project": {
       "title": "Set Up a Project",

--- a/frontend/src/i18n/locales/en/workflow.json
+++ b/frontend/src/i18n/locales/en/workflow.json
@@ -198,6 +198,10 @@
       "zhipuaiOpenai": "ZhipuAI detected. Consider using \"openai-compatible\" as the API type.",
       "zhipuaiAnthropic": "ZhipuAI detected. Consider using \"anthropic-compatible\" as the API type.",
       "urlHint": "Enter the complete base URL. It will be used exactly as-is (e.g. https://api.example.com/v1)."
+    },
+    "hints": {
+      "officialModels": "Official API: built-in model list is suggested — you can also type any model ID.",
+      "compatibleModels": "Compatible endpoint: fetch the model list from the endpoint, or type the model ID manually."
     }
   },
   "step4": {

--- a/frontend/src/i18n/locales/es/setup.json
+++ b/frontend/src/i18n/locales/es/setup.json
@@ -9,14 +9,14 @@
     },
     "welcome": {
       "title": "Bienvenido a SoloDawn",
-      "subtitle": "Configuremos tu entorno en unos sencillos pasos. Puedes omitir este proceso y configurar todo m\u00e1s tarde en Ajustes.",
+      "subtitle": "Configuremos tu entorno en unos sencillos pasos. Puedes omitir este proceso y configurar todo más tarde en Ajustes.",
       "languageLabel": "Idioma",
       "continueButton": "Continuar",
-      "skipButton": "Omitir configuraci\u00f3n"
+      "skipButton": "Omitir configuración"
     },
     "model": {
       "title": "Configurar un modelo de IA",
-      "subtitle": "SoloDawn necesita al menos un modelo de IA para ejecutar flujos de trabajo. Puedes agregar m\u00e1s posteriormente en Ajustes.",
+      "subtitle": "SoloDawn necesita al menos un modelo de IA para ejecutar flujos de trabajo. Puedes agregar más posteriormente en Ajustes.",
       "displayNameLabel": "Nombre visible",
       "displayNamePlaceholder": "ej. Mi API de Claude",
       "apiTypeLabel": "Tipo de API",
@@ -28,43 +28,45 @@
       "modelIdPlaceholder": "Selecciona un modelo",
       "fetchModelsButton": "Obtener modelos",
       "fetchingModels": "Obteniendo modelos...",
-      "verifyButton": "Verificar conexi\u00f3n",
+      "verifyButton": "Verificar conexión",
       "verifying": "Verificando...",
-      "verified": "Conexi\u00f3n verificada",
-      "verifyFailed": "La verificaci\u00f3n fall\u00f3. Revisa tu clave de API y la configuraci\u00f3n.",
-      "nativeTab": "Suscripci\u00f3n",
+      "verified": "Conexión verificada",
+      "verifyFailed": "La verificación falló. Revisa tu clave de API y la configuración.",
+      "nativeTab": "Suscripción",
       "manualTab": "Clave de API",
-      "nativeDetecting": "Detectando suscripci\u00f3n local...",
-      "nativeDetected": "Suscripci\u00f3n de Claude Code detectada",
+      "nativeDetecting": "Detectando suscripción local...",
+      "nativeDetected": "Suscripción de Claude Code detectada",
       "nativeModelLabel": "Modelo",
-      "nativeModelAuto": "Auto (seg\u00fan suscripci\u00f3n)",
+      "nativeModelAuto": "Auto (según suscripción)",
       "nativeCurrentDefault": "predeterminado actual",
-      "nativeModelSwitchHint": "Establece el modelo predeterminado para las ejecuciones por suscripci\u00f3n \u2014 se aplica a los modos DIY y Agent Planned; cada terminal puede elegir otro modelo.",
-      "nativeVersionLabel": "Versi\u00f3n del CLI",
-      "nativeHint": "Se utilizar\u00e1 directamente tu cuenta de Claude Code ya iniciada \u2014 no se necesita clave de API.",
-      "nativeNotFound": "No se detect\u00f3 una suscripci\u00f3n activa",
-      "nativeNotFoundHint": "Primero inicia sesi\u00f3n en Claude Code (ejecuta \"claude\" en la terminal), o cambia a la pesta\u00f1a \"Clave de API\" para ingresar las credenciales manualmente.",
-      "skipHint": "Puedes omitir este paso y configurar modelos m\u00e1s tarde en Ajustes \u2192 Modelos.",
+      "nativeModelSwitchHint": "Establece el modelo predeterminado para las ejecuciones por suscripción — se aplica a los modos DIY y Agent Planned; cada terminal puede elegir otro modelo.",
+      "nativeVersionLabel": "Versión del CLI",
+      "nativeHint": "Se utilizará directamente tu cuenta de Claude Code ya iniciada — no se necesita clave de API.",
+      "nativeNotFound": "No se detectó una suscripción activa",
+      "nativeNotFoundHint": "Primero inicia sesión en Claude Code (ejecuta \"claude\" en la terminal), o cambia a la pestaña \"Clave de API\" para ingresar las credenciales manualmente.",
+      "skipHint": "Puedes omitir este paso y configurar modelos más tarde en Ajustes → Modelos.",
       "apiTypes": {
         "anthropic": "Anthropic",
         "anthropicCompatible": "Anthropic Compatible",
         "openai": "OpenAI",
         "google": "Google AI",
         "openaiCompatible": "Compatible con OpenAI"
-      }
+      },
+      "officialModelsHint": "API oficial: se sugiere la lista de modelos integrada; también puedes escribir cualquier ID de modelo.",
+      "compatibleModelsHint": "Endpoint compatible: obtén la lista de modelos desde el endpoint o escribe el ID del modelo manualmente."
     },
     "project": {
       "title": "Configurar un proyecto",
-      "subtitle": "Selecciona un directorio de trabajo para tu primer proyecto. SoloDawn gestionar\u00e1 tu c\u00f3digo en esta ubicaci\u00f3n.",
+      "subtitle": "Selecciona un directorio de trabajo para tu primer proyecto. SoloDawn gestionará tu código en esta ubicación.",
       "optionalBadge": "Opcional",
       "directoryLabel": "Directorio de trabajo",
       "directoryPlaceholder": "Selecciona un directorio...",
       "browseButton": "Explorar",
       "continueButton": "Continuar",
       "skipButton": "Omitir",
-      "skipHint": "Puedes omitir este paso y crear proyectos m\u00e1s tarde desde el tablero.",
+      "skipHint": "Puedes omitir este paso y crear proyectos más tarde desde el tablero.",
       "checking": "Verificando directorio...",
-      "validGitRepo": "Repositorio Git v\u00e1lido detectado",
+      "validGitRepo": "Repositorio Git válido detectado",
       "notGitRepo": "Este directorio no es un repositorio Git",
       "directoryNotFound": "Directorio no encontrado",
       "checkFailed": "Error al verificar el directorio",
@@ -75,7 +77,7 @@
       "subtitle": "Conecta SoloDawn con tus herramientas favoritas. Todas las integraciones son opcionales.",
       "feishu": {
         "label": "Feishu / Lark",
-        "description": "Recibe notificaciones de flujos de trabajo e interact\u00faa con SoloDawn a trav\u00e9s del bot de Feishu.",
+        "description": "Recibe notificaciones de flujos de trabajo e interactúa con SoloDawn a través del bot de Feishu.",
         "appIdLabel": "App ID",
         "appIdPlaceholder": "Introduce el App ID de Feishu",
         "appSecretLabel": "App Secret",
@@ -84,10 +86,10 @@
       "skipHint": "Puedes configurar integraciones en cualquier momento desde Ajustes."
     },
     "done": {
-      "title": "\u00a1Todo listo!",
-      "subtitle": "SoloDawn est\u00e1 preparado. Comienza creando tu primer flujo de trabajo.",
+      "title": "¡Todo listo!",
+      "subtitle": "SoloDawn está preparado. Comienza creando tu primer flujo de trabajo.",
       "getStartedButton": "Comenzar",
-      "rerunHint": "Puedes volver a ejecutar esta configuraci\u00f3n en cualquier momento desde Ajustes."
+      "rerunHint": "Puedes volver a ejecutar esta configuración en cualquier momento desde Ajustes."
     }
   }
 }

--- a/frontend/src/i18n/locales/es/workflow.json
+++ b/frontend/src/i18n/locales/es/workflow.json
@@ -198,6 +198,10 @@
       "zhipuaiOpenai": "Se detectó ZhipuAI. Considere usar \"openai-compatible\" como tipo de API.",
       "zhipuaiAnthropic": "Se detectó ZhipuAI. Considere usar \"anthropic-compatible\" como tipo de API.",
       "urlHint": "Ingrese la URL base completa. Se usará tal cual (ej. https://api.example.com/v1)."
+    },
+    "hints": {
+      "officialModels": "API oficial: se sugiere la lista de modelos integrada; también puedes escribir cualquier ID de modelo.",
+      "compatibleModels": "Endpoint compatible: obtén la lista de modelos desde el endpoint o escribe el ID del modelo manualmente."
     }
   },
   "step4": {

--- a/frontend/src/i18n/locales/ja/setup.json
+++ b/frontend/src/i18n/locales/ja/setup.json
@@ -51,7 +51,9 @@
         "openai": "OpenAI",
         "google": "Google AI",
         "openaiCompatible": "OpenAI 互換"
-      }
+      },
+      "officialModelsHint": "公式 API：組み込みのモデルリストを候補表示します。任意のモデル ID を直接入力することもできます。",
+      "compatibleModelsHint": "互換エンドポイント：エンドポイントからモデルリストを取得するか、モデル ID を手動で入力してください。"
     },
     "project": {
       "title": "プロジェクトを設定",

--- a/frontend/src/i18n/locales/ja/workflow.json
+++ b/frontend/src/i18n/locales/ja/workflow.json
@@ -198,6 +198,10 @@
       "zhipuaiOpenai": "ZhipuAIが検出されました。APIタイプを \"openai-compatible\" に変更することを検討してください。",
       "zhipuaiAnthropic": "ZhipuAIが検出されました。APIタイプを \"anthropic-compatible\" に変更することを検討してください。",
       "urlHint": "完全なベースURLを入力してください。入力された通りに使用されます（例：https://api.example.com/v1）。"
+    },
+    "hints": {
+      "officialModels": "公式 API：組み込みのモデルリストを候補表示します。任意のモデル ID を直接入力することもできます。",
+      "compatibleModels": "互換エンドポイント：エンドポイントからモデルリストを取得するか、モデル ID を手動で入力してください。"
     }
   },
   "step4": {

--- a/frontend/src/i18n/locales/ko/setup.json
+++ b/frontend/src/i18n/locales/ko/setup.json
@@ -51,7 +51,9 @@
         "openai": "OpenAI",
         "google": "Google AI",
         "openaiCompatible": "OpenAI 호환"
-      }
+      },
+      "officialModelsHint": "공식 API: 내장 모델 목록이 제안됩니다. 모델 ID를 직접 입력할 수도 있습니다.",
+      "compatibleModelsHint": "호환 엔드포인트: 엔드포인트에서 모델 목록을 가져오거나 모델 ID를 직접 입력하세요."
     },
     "project": {
       "title": "프로젝트 설정",

--- a/frontend/src/i18n/locales/ko/workflow.json
+++ b/frontend/src/i18n/locales/ko/workflow.json
@@ -198,6 +198,10 @@
       "zhipuaiOpenai": "ZhipuAI가 감지되었습니다. API 유형을 \"openai-compatible\"로 변경하는 것을 고려하세요.",
       "zhipuaiAnthropic": "ZhipuAI가 감지되었습니다. API 유형을 \"anthropic-compatible\"로 변경하는 것을 고려하세요.",
       "urlHint": "전체 기본 URL을 입력하세요. 입력한 그대로 사용됩니다 (예: https://api.example.com/v1)."
+    },
+    "hints": {
+      "officialModels": "공식 API: 내장 모델 목록이 제안됩니다. 모델 ID를 직접 입력할 수도 있습니다.",
+      "compatibleModels": "호환 엔드포인트: 엔드포인트에서 모델 목록을 가져오거나 모델 ID를 직접 입력하세요."
     }
   },
   "step4": {

--- a/frontend/src/i18n/locales/zh-Hans/setup.json
+++ b/frontend/src/i18n/locales/zh-Hans/setup.json
@@ -53,7 +53,9 @@
         "openai": "OpenAI",
         "google": "Google AI",
         "openaiCompatible": "OpenAI 兼容"
-      }
+      },
+      "officialModelsHint": "官方 API：已内置模型列表，也可直接输入任意模型 ID。",
+      "compatibleModelsHint": "兼容端点：可从端点获取模型列表，或手动输入模型 ID。"
     },
     "project": {
       "title": "设置项目",

--- a/frontend/src/i18n/locales/zh-Hans/workflow.json
+++ b/frontend/src/i18n/locales/zh-Hans/workflow.json
@@ -199,6 +199,10 @@
       "zhipuaiOpenai": "检测到智谱AI地址。建议将 API 类型更改为 \"openai-compatible\"。",
       "zhipuaiAnthropic": "检测到智谱AI地址。建议将 API 类型更改为 \"anthropic-compatible\"。",
       "urlHint": "请输入完整的基础 URL，系统将原样使用（例如 https://api.example.com/v1）。"
+    },
+    "hints": {
+      "officialModels": "官方 API：已内置模型列表，也可直接输入任意模型 ID。",
+      "compatibleModels": "兼容端点：可从端点获取模型列表，或手动输入模型 ID。"
     }
   },
   "step4": {

--- a/frontend/src/i18n/locales/zh-Hant/setup.json
+++ b/frontend/src/i18n/locales/zh-Hant/setup.json
@@ -51,7 +51,9 @@
         "openai": "OpenAI",
         "google": "Google AI",
         "openaiCompatible": "OpenAI 相容"
-      }
+      },
+      "officialModelsHint": "官方 API：已內建模型列表，也可直接輸入任意模型 ID。",
+      "compatibleModelsHint": "相容端點：可從端點取得模型列表，或手動輸入模型 ID。"
     },
     "project": {
       "title": "設定專案",

--- a/frontend/src/i18n/locales/zh-Hant/workflow.json
+++ b/frontend/src/i18n/locales/zh-Hant/workflow.json
@@ -198,6 +198,10 @@
       "zhipuaiOpenai": "偵測到智譜AI位址。建議將 API 類型更改為 \"openai-compatible\"。",
       "zhipuaiAnthropic": "偵測到智譜AI位址。建議將 API 類型更改為 \"anthropic-compatible\"。",
       "urlHint": "請輸入完整的基礎 URL，系統將原樣使用（例如 https://api.example.com/v1）。"
+    },
+    "hints": {
+      "officialModels": "官方 API：已內建模型列表，也可直接輸入任意模型 ID。",
+      "compatibleModels": "相容端點：可從端點取得模型列表，或手動輸入模型 ID。"
     }
   },
   "step4": {

--- a/frontend/src/stores/modelStore.ts
+++ b/frontend/src/stores/modelStore.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { create } from 'zustand';
 import type { ModelConfig, ApiType } from '@/components/workflow/types';
+import { OFFICIAL_MODELS } from '@/components/workflow/modelCatalog';
 
 /**
  * Model state management store
@@ -39,21 +40,6 @@ interface ModelStoreState {
   // Reset
   reset: () => void;
 }
-
-// Default models for each API type (fallback when API fetch fails)
-const DEFAULT_MODELS: Record<ApiType, string[]> = {
-  anthropic: [
-    'claude-opus-4-8',
-    'claude-sonnet-5',
-    'claude-haiku-4-5',
-    'claude-opus-4-7',
-    'claude-sonnet-4-6',
-  ],
-  'anthropic-compatible': [],
-  google: ['gemini-2.0-flash-exp', 'gemini-1.5-pro', 'gemini-1.5-flash'],
-  openai: ['gpt-4o', 'gpt-4-turbo', 'gpt-4', 'gpt-3.5-turbo'],
-  'openai-compatible': [],
-};
 
 export const useModelStore = create<ModelStoreState>((set, get) => ({
   // Initial state
@@ -124,8 +110,8 @@ export const useModelStore = create<ModelStoreState>((set, get) => ({
       const errorMessage = error instanceof Error ? error.message : 'Failed to fetch models';
       set({ error: errorMessage, isFetching: false });
 
-      // Return default models as fallback
-      const defaultModels = DEFAULT_MODELS[apiType] ?? [];
+      // Return the built-in models as fallback
+      const defaultModels = [...(OFFICIAL_MODELS[apiType] ?? [])];
       get().setAvailableModels(apiType, defaultModels);
       return defaultModels;
     }
@@ -177,7 +163,7 @@ export const useModelStore = create<ModelStoreState>((set, get) => ({
 
   getAvailableModels: (apiType) => {
     const models = get().availableModels.get(apiType);
-    return models ?? DEFAULT_MODELS[apiType as ApiType] ?? [];
+    return models ?? [...(OFFICIAL_MODELS[apiType as ApiType] ?? [])];
   },
 
   setLoading: (loading) => {
@@ -229,5 +215,7 @@ export function useVerifiedModels() {
  */
 export function useAvailableModels(apiType: string) {
   const availableModels = useModelStore((state) => state.availableModels);
-  return availableModels.get(apiType) ?? DEFAULT_MODELS[apiType as ApiType] ?? [];
+  return (
+    availableModels.get(apiType) ?? [...(OFFICIAL_MODELS[apiType as ApiType] ?? [])]
+  );
 }

--- a/scripts/run-dev.js
+++ b/scripts/run-dev.js
@@ -295,7 +295,11 @@ function run(name, command, args, options) {
   const resolved = resolveCommand(command, args);
   ensureLogStreams();
   const spawnOptions = {
-    stdio: ["inherit", "pipe", "pipe"],
+    // stdin must NOT be inherited: run-dev itself reads its stdin (the Ctrl+C
+    // readline below), and two readers on one Windows console handle deadlock
+    // a child that installs stdin listeners (e.g. vite's CLI shortcuts) before
+    // it ever binds its port. No child needs stdin — drop it.
+    stdio: ["ignore", "pipe", "pipe"],
     ...options
   };
   const executable = resolveExecutable(resolved.command, spawnOptions.env ?? process.env);
@@ -599,15 +603,21 @@ async function main() {
   // terminating/stale previous vite processes.
   await ensurePortAvailable(ports.frontend, "Frontend");
 
-  // Start frontend
+  // Start frontend by spawning Vite directly with the current Node executable.
+  // Going through `npm run dev` re-enters the invoking package manager via
+  // npm_execpath (pnpm when launched as `pnpm run dev`); a broken pnpm
+  // self-managed install then hangs before Vite ever starts. Vite needs no
+  // package-manager layer, so skip it entirely.
+  const frontendDir = path.join(__dirname, "..", "frontend");
+  const viteBin = path.join(frontendDir, "node_modules", "vite", "bin", "vite.js");
+  if (!fs.existsSync(viteBin)) {
+    throw new Error(`Vite is not installed at ${viteBin}. Run \`pnpm install\` first.`);
+  }
   run(
     "frontend",
-    "npm",
-    ["run", "dev", "--", "--port", String(ports.frontend), "--host"],
-    {
-      env,
-      cwd: path.join(__dirname, "..", "frontend"),
-    }
+    process.execPath,
+    [viteBin, "--port", String(ports.frontend), "--host"],
+    { env, cwd: frontendDir }
   );
 
   console.log("[dev] Development servers started successfully");

--- a/scripts/run-frontend-dev.js
+++ b/scripts/run-frontend-dev.js
@@ -1,20 +1,8 @@
 #!/usr/bin/env node
 
 const path = require("node:path");
+const fs = require("node:fs");
 const { spawn } = require("node:child_process");
-
-function resolveNpmCommand(args) {
-  if (process.platform !== "win32") {
-    return { command: "npm", args };
-  }
-
-  const npmExecPath = process.env.npm_execpath;
-  if (npmExecPath) {
-    return { command: process.execPath, args: [npmExecPath, ...args] };
-  }
-
-  return { command: "cmd.exe", args: ["/d", "/s", "/c", "npm", ...args] };
-}
 
 function main() {
   const port = String(process.env.FRONTEND_PORT || "23457");
@@ -22,11 +10,17 @@ function main() {
     ...process.env,
     FRONTEND_PORT: port,
   };
-  const npmArgs = ["run", "dev", "--", "--port", port, "--host"];
-  const resolved = resolveNpmCommand(npmArgs);
+  // Spawn Vite directly with the current Node executable — avoids re-entering
+  // the invoking package manager via npm_execpath (see scripts/run-dev.js).
+  const frontendDir = path.join(__dirname, "..", "frontend");
+  const viteBin = path.join(frontendDir, "node_modules", "vite", "bin", "vite.js");
+  if (!fs.existsSync(viteBin)) {
+    console.error(`[frontend:dev] Vite is not installed at ${viteBin}. Run \`pnpm install\` first.`);
+    process.exit(1);
+  }
 
-  const child = spawn(resolved.command, resolved.args, {
-    cwd: path.join(__dirname, "..", "frontend"),
+  const child = spawn(process.execPath, [viteBin, "--port", port, "--host"], {
+    cwd: frontendDir,
     stdio: "inherit",
     env,
   });


### PR DESCRIPTION
## Summary

Two independent fixes, one per commit:

### 1. `fix(dev)`: frontend dev server never started on Windows

`pnpm run dev` brought up the backend but vite hung forever with zero output. Two root causes in the launcher scripts:

- **stdin contention deadlock** — `scripts/run-dev.js` reads its own stdin (the Windows Ctrl+C readline) *and* passed `stdio: "inherit"` to children. Two concurrent readers on one Windows console handle deadlock any child that installs stdin listeners during startup — vite wires its CLI shortcuts before binding its port. Children now get `stdio: ["ignore", "pipe", "pipe"]`; no child needs stdin.
- **package-manager re-entry** — the frontend was spawned via `npm run dev`, which re-enters the invoking package manager through `npm_execpath`; a broken pnpm self-managed install then hangs before vite even spawns. Both dev scripts now spawn vite directly with the current Node executable and fail fast with a clear message if `node_modules` is missing.

### 2. `feat(models)`: official vs compatible model-config UX + catalog refresh

Users reported 获取模型列表 failing/misleading with custom models. The fetch transport (backend `/api/models/list` proxy) was fine — the UI contract around it was broken:

- Fetch button rendered for **every** API type (pointless for official Anthropic/OpenAI/Google) and enabled before a base URL existed.
- On fetch failure, a stale hardcoded list (gpt-4 / gpt-3.5-turbo / gemini-1.5 era) silently appeared in a locked `<select>`, and any non-empty list forced a `<select>` that blocked manual model-ID entry.

Now:

- Fetch button renders **only** for `anthropic-compatible` / `openai-compatible`, enabled only once API key + base URL are both filled (DIY wizard + setup wizard).
- Official APIs skip fetching entirely — the built-in catalog feeds the model field as suggestions.
- Model field is a free-text input with `<datalist>` suggestions everywhere; any model ID can always be typed.
- Per-mode hint line under the model field, translated in all 6 locales.
- New `frontend/src/components/workflow/modelCatalog.ts` is the single source of truth for built-in catalogs (July-2026 lineups: Claude Fable 5 / Opus 4.8 / Sonnet 5 / Haiku 4.5; GPT-5.5 / 5.4 family; Gemini 3.5 / 3.1 family), replacing three divergent hardcoded copies (`modelStore`, `useModelVerification`, `Step3Models`).

Note: `es/setup.json` had pre-existing `\uXXXX` escapes normalized to literal UTF-8 by the JSON round-trip; strings are equivalent after parse.

## Test plan

- [x] `pnpm run dev` on Windows: backend ready on :23456, vite ready in <1s on :23457, HTTP 200
- [x] Frontend: 517/517 vitest (76 files), `eslint --max-warnings 0` clean, `tsc --noEmit` clean
- [x] New Step3Models tests: button hidden for official types, shown for compatible; built-in suggestions for official; fetched suggestions for compatible (mocked `/api/models/list`)
- [x] Live browser check of both wizard branches (official: no button + catalog hint; compatible: gated button + endpoint hint)
- [x] Manually verified by @huanchong-99 against a real relay endpoint: model list fetched and suggested correctly in anthropic-compatible mode
