### PR TITLE
fix: enable deleting orchestrated-workspace conversations & submit Codex prompt in DIY mode

### DIFF
--- a/crates/db/src/models/planning_draft.rs
+++ b/crates/db/src/models/planning_draft.rs
@@ -323,6 +323,29 @@ impl PlanningDraft {
         Ok(())
     }
 
+    /// Hard-delete a planning draft (and its messages).
+    ///
+    /// `planning_draft_message` rows are removed automatically via
+    /// `ON DELETE CASCADE`. Child rounds that continue this draft via
+    /// `parent_draft_id` (a self-referential FK with no cascade) are detached
+    /// first so the constraint does not block the delete — those rounds become
+    /// standalone rather than being deleted. The `materialized_workflow_id`
+    /// pointer is `ON DELETE SET NULL` from the workflow side and is unaffected
+    /// here, so deleting a materialized draft leaves its workflow intact.
+    ///
+    /// Returns the number of draft rows deleted (0 if the id did not exist).
+    pub async fn delete(pool: &SqlitePool, id: &str) -> sqlx::Result<u64> {
+        sqlx::query("UPDATE planning_draft SET parent_draft_id = NULL WHERE parent_draft_id = ?1")
+            .bind(id)
+            .execute(pool)
+            .await?;
+        let result = sqlx::query("DELETE FROM planning_draft WHERE id = ?1")
+            .bind(id)
+            .execute(pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
     pub async fn update_feishu_sync(
         pool: &SqlitePool,
         id: &str,
@@ -511,5 +534,62 @@ mod tests {
             .unwrap()
             .expect("child draft should be discoverable from its parent");
         assert_eq!(found_child.id, child.id);
+    }
+
+    #[tokio::test]
+    async fn delete_cascades_messages_and_detaches_child_rounds() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::run_migrations(&pool).await.unwrap();
+        let project_id = Uuid::new_v4();
+        crate::models::project::Project::create(
+            &pool,
+            &crate::models::project::CreateProject {
+                name: "delete-test".to_string(),
+                repositories: vec![],
+            },
+            project_id,
+        )
+        .await
+        .unwrap();
+
+        // Parent draft with a message, plus a child round linked by parent_draft_id.
+        let parent = PlanningDraft::new(project_id, "memo app");
+        PlanningDraft::insert(&pool, &parent).await.unwrap();
+        PlanningDraftMessage::insert(
+            &pool,
+            &PlanningDraftMessage::new(&parent.id, "user", "Build a memo app"),
+        )
+        .await
+        .unwrap();
+
+        let mut child = PlanningDraft::new(project_id, "memo app v2");
+        child.parent_draft_id = Some(parent.id.clone());
+        PlanningDraft::insert(&pool, &child).await.unwrap();
+
+        // Delete the parent.
+        let rows = PlanningDraft::delete(&pool, &parent.id).await.unwrap();
+        assert_eq!(rows, 1, "exactly one draft row deleted");
+
+        // Parent is gone and its messages cascaded away.
+        assert!(PlanningDraft::find_by_id(&pool, &parent.id)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(PlanningDraftMessage::list_by_draft(&pool, &parent.id)
+            .await
+            .unwrap()
+            .is_empty());
+
+        // Child survives the delete but is detached from the removed parent, so
+        // the self-referential FK does not block the delete.
+        let surviving_child = PlanningDraft::find_by_id(&pool, &child.id)
+            .await
+            .unwrap()
+            .expect("child round should outlive its deleted parent");
+        assert!(surviving_child.parent_draft_id.is_none());
+
+        // Deleting an unknown id is a no-op that reports zero rows.
+        let rows = PlanningDraft::delete(&pool, "does-not-exist").await.unwrap();
+        assert_eq!(rows, 0);
     }
 }

--- a/crates/server/src/routes/planning_drafts.rs
+++ b/crates/server/src/routes/planning_drafts.rs
@@ -173,7 +173,7 @@ async fn push_messages_to_feishu(
 pub fn planning_draft_routes() -> Router<DeploymentImpl> {
     Router::new()
         .route("/", post(create_draft).get(list_drafts))
-        .route("/{draft_id}", get(get_draft))
+        .route("/{draft_id}", get(get_draft).delete(delete_draft))
         .route("/{draft_id}/spec", put(update_spec))
         .route("/{draft_id}/confirm", post(confirm_draft))
         .route("/{draft_id}/confirm-gates", post(confirm_gates))
@@ -1647,6 +1647,52 @@ async fn delete_audit_doc(
         .ok_or_else(|| ApiError::Internal("Draft disappeared after update".to_string()))?;
 
     Ok(Json(ApiResponse::success(DraftResponse::from(updated))))
+}
+
+/// Delete a planning draft (an orchestrated-workspace conversation) and its
+/// messages. Best-effort removes any uploaded audit document from disk first,
+/// reusing the same path-safety guard as `delete_audit_doc` so a crafted stored
+/// path cannot delete an arbitrary file. Returns 404 if the draft is missing.
+async fn delete_draft(
+    State(deployment): State<DeploymentImpl>,
+    Path(draft_id): Path<String>,
+) -> Result<ResponseJson<ApiResponse<()>>, ApiError> {
+    let draft = PlanningDraft::find_by_id(&deployment.db().pool, &draft_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| ApiError::NotFound(format!("Planning draft {draft_id} not found")))?;
+
+    // Best-effort disk cleanup for an uploaded audit doc. The DB delete below is
+    // the source of truth, so file-removal issues only warn. Skip disk removal
+    // for any legacy path that could traverse outside the audit-docs dir.
+    if let Some(ref doc_path) = draft.audit_doc_path {
+        if reject_unsafe_doc_path(doc_path).is_err() {
+            tracing::warn!(
+                draft_id = %draft_id,
+                "Refusing to remove audit doc with unsafe stored path during draft delete"
+            );
+        } else {
+            let full_path = audit_docs_dir().join(doc_path);
+            if let Err(e) = tokio::fs::remove_file(&full_path).await {
+                tracing::warn!(
+                    draft_id = %draft_id,
+                    path = %full_path.display(),
+                    error = %e,
+                    "Failed to remove audit doc file during draft delete"
+                );
+            }
+            let parent_dir = audit_docs_dir().join(&draft_id);
+            let _ = tokio::fs::remove_dir(&parent_dir).await; // ignore errors (may not be empty)
+        }
+    }
+
+    let deleted = PlanningDraft::delete(&deployment.db().pool, &draft_id)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to delete draft: {e}")))?;
+
+    tracing::info!(draft_id = %draft_id, rows = deleted, "Planning draft deleted");
+
+    Ok(Json(ApiResponse::success(())))
 }
 
 #[cfg(test)]

--- a/crates/server/src/routes/workflows.rs
+++ b/crates/server/src/routes/workflows.rs
@@ -2193,6 +2193,7 @@ async fn start_workflow(
                 Vec::new()
             };
             tokio::spawn(async move {
+                use services::services::terminal::submit_policy;
                 for (task_id, task_name, task_description) in &dispatch_tasks {
                     let task_terminals = match Terminal::find_by_task(&dispatch_db, task_id).await {
                         Ok(t) => t,
@@ -2215,11 +2216,34 @@ async fn start_workflow(
                                         None,
                                     )
                                     .await;
-                                // Send submit keystroke after a brief delay
-                                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                                dispatch_bus
-                                    .publish_terminal_input(&terminal.id, pty_session_id, "", None)
+                                // Submit keystrokes are CLI-specific: Codex keeps the
+                                // pasted instruction in its composer until it receives
+                                // several explicit Enters (cold-start TUI frames can
+                                // swallow the first one or two), whereas Claude Code and
+                                // others submit on the instruction's own trailing carriage
+                                // return. Mirrors the orchestrator's dispatch so DIY and
+                                // agent-planned modes drive each CLI identically; before
+                                // this fix DIY sent a single generic Enter, which left
+                                // Codex's prompt unsubmitted (terminal "initialised, then
+                                // did nothing").
+                                for &delay_ms in
+                                    submit_policy::initial_submit_keystroke_schedule_ms(
+                                        &terminal.cli_type_id,
+                                    )
+                                {
+                                    tokio::time::sleep(std::time::Duration::from_millis(
+                                        delay_ms,
+                                    ))
                                     .await;
+                                    dispatch_bus
+                                        .publish_terminal_input(
+                                            &terminal.id,
+                                            pty_session_id,
+                                            "",
+                                            None,
+                                        )
+                                        .await;
+                                }
                                 tracing::info!(
                                     terminal_id = %terminal.id,
                                     task_name = %task_name,
@@ -2236,10 +2260,24 @@ async fn start_workflow(
                                         None,
                                     )
                                     .await;
-                                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                                dispatch_bus
-                                    .publish_terminal_input(&terminal.id, pty_session_id, "", None)
+                                for &delay_ms in
+                                    submit_policy::followup_submit_keystroke_schedule_ms(
+                                        &terminal.cli_type_id,
+                                    )
+                                {
+                                    tokio::time::sleep(std::time::Duration::from_millis(
+                                        delay_ms,
+                                    ))
                                     .await;
+                                    dispatch_bus
+                                        .publish_terminal_input(
+                                            &terminal.id,
+                                            pty_session_id,
+                                            "",
+                                            None,
+                                        )
+                                        .await;
+                                }
                                 tracing::info!(
                                     terminal_id = %terminal.id,
                                     command = %command_name,

--- a/crates/services/src/services/orchestrator/agent.rs
+++ b/crates/services/src/services/orchestrator/agent.rs
@@ -8593,31 +8593,26 @@ impl OrchestratorAgent {
     }
 
     fn needs_explicit_submit(terminal: &db::models::Terminal) -> bool {
-        terminal.cli_type_id.to_ascii_lowercase().contains("codex")
+        // Shared with the DIY/manual dispatch path so a CLI is driven identically
+        // regardless of execution mode. See `terminal::submit_policy`.
+        crate::services::terminal::submit_policy::cli_needs_explicit_submit(&terminal.cli_type_id)
     }
 
     fn is_claude_code_cli(terminal: &db::models::Terminal) -> bool {
-        terminal
-            .cli_type_id
-            .to_ascii_lowercase()
-            .contains("claude-code")
+        crate::services::terminal::submit_policy::cli_is_claude_code(&terminal.cli_type_id)
     }
 
     fn submit_keystroke_schedule_ms(
         terminal: &db::models::Terminal,
         is_initial_dispatch: bool,
     ) -> &'static [u64] {
-        if Self::needs_explicit_submit(terminal) {
-            &[120, 360, 900]
-        } else if is_initial_dispatch && Self::is_claude_code_cli(terminal) {
-            // Claude Code occasionally leaves the first pasted prompt in composer without
-            // submission on cold start; send one delayed Enter only for initial dispatch.
-            &[420]
+        // Delegates to the shared submit policy (single source of truth for how
+        // each CLI's TUI is coaxed into submitting a pasted instruction).
+        use crate::services::terminal::submit_policy;
+        if is_initial_dispatch {
+            submit_policy::initial_submit_keystroke_schedule_ms(&terminal.cli_type_id)
         } else {
-            // Non-Codex CLIs receive the instruction as a single message payload that already
-            // includes a submit key. Extra synthetic Enter keystrokes can race startup TUIs and
-            // accidentally submit partial/empty prompts.
-            &[]
+            submit_policy::followup_submit_keystroke_schedule_ms(&terminal.cli_type_id)
         }
     }
 

--- a/crates/services/src/services/terminal/mod.rs
+++ b/crates/services/src/services/terminal/mod.rs
@@ -16,6 +16,7 @@ pub mod output_fanout;
 pub mod process;
 pub mod prompt_detector;
 pub mod prompt_watcher;
+pub mod submit_policy;
 pub mod utf8_decoder;
 
 pub use bridge::TerminalBridge;

--- a/crates/services/src/services/terminal/submit_policy.rs
+++ b/crates/services/src/services/terminal/submit_policy.rs
@@ -1,0 +1,130 @@
+//! CLI-specific submit-keystroke policy.
+//!
+//! When SoloDawn dispatches a terminal's initial instruction it pastes the text
+//! into the CLI's TUI composer. Different CLIs need different follow-up to make
+//! the composer actually *submit* that text:
+//!
+//! - **Codex** keeps pasted text in its composer until it receives explicit
+//!   Enter keystroke(s); cold-start TUI frames can also swallow the first one or
+//!   two, so several spaced Enters are required.
+//! - **Claude Code** normally submits on the instruction's own trailing carriage
+//!   return, but occasionally leaves the *first* pasted prompt in the composer on
+//!   cold start, so one delayed Enter is sent on the initial dispatch as a safety.
+//! - **Other CLIs** submit on the instruction payload's own trailing carriage
+//!   return; injecting extra synthetic Enters can race the startup TUI and submit
+//!   partial/empty input.
+//!
+//! This policy is the single source of truth shared by both dispatch paths — the
+//! orchestrator (agent-planned mode) and the DIY/manual-workflow dispatcher — so
+//! a given CLI is driven identically regardless of execution mode. Prior to this
+//! module the DIY path hard-coded a single generic Enter, which was enough for
+//! Claude Code but left Codex's prompt sitting unsubmitted in the composer (the
+//! terminal "initialised, then did nothing").
+
+/// Submit-keystroke delays (ms) for Codex — three spaced Enters.
+const CODEX_SUBMIT_SCHEDULE_MS: &[u64] = &[120, 360, 900];
+
+/// Submit-keystroke delay (ms) for Claude Code's initial dispatch — one Enter.
+const CLAUDE_INITIAL_SUBMIT_SCHEDULE_MS: &[u64] = &[420];
+
+/// No follow-up submit keystrokes.
+const NO_SUBMIT_SCHEDULE_MS: &[u64] = &[];
+
+/// True if this CLI's TUI keeps pasted text in the composer until an explicit
+/// Enter keystroke is sent (currently: Codex).
+pub fn cli_needs_explicit_submit(cli_type_id: &str) -> bool {
+    cli_type_id.to_ascii_lowercase().contains("codex")
+}
+
+/// True if this CLI is Claude Code.
+pub fn cli_is_claude_code(cli_type_id: &str) -> bool {
+    cli_type_id.to_ascii_lowercase().contains("claude-code")
+}
+
+/// Submit-keystroke schedule (ms delays between successive Enters) to send after
+/// the **initial** instruction dispatch, keyed on the CLI type id.
+///
+/// See the module docs for the rationale behind each schedule.
+pub fn initial_submit_keystroke_schedule_ms(cli_type_id: &str) -> &'static [u64] {
+    if cli_needs_explicit_submit(cli_type_id) {
+        CODEX_SUBMIT_SCHEDULE_MS
+    } else if cli_is_claude_code(cli_type_id) {
+        CLAUDE_INITIAL_SUBMIT_SCHEDULE_MS
+    } else {
+        NO_SUBMIT_SCHEDULE_MS
+    }
+}
+
+/// Submit-keystroke schedule for a **non-initial** dispatch (e.g. a follow-up
+/// instruction or a slash-command prompt typed after the first one). Only CLIs
+/// that need explicit submission (Codex) get keystrokes here; Claude Code's
+/// cold-start safety Enter applies to the initial dispatch only.
+pub fn followup_submit_keystroke_schedule_ms(cli_type_id: &str) -> &'static [u64] {
+    if cli_needs_explicit_submit(cli_type_id) {
+        CODEX_SUBMIT_SCHEDULE_MS
+    } else {
+        NO_SUBMIT_SCHEDULE_MS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_variants_need_explicit_submit() {
+        assert!(cli_needs_explicit_submit("codex"));
+        assert!(cli_needs_explicit_submit("Codex"));
+        assert!(cli_needs_explicit_submit("cli-codex"));
+        assert!(cli_needs_explicit_submit("codex-gpt-5"));
+        assert!(!cli_needs_explicit_submit("claude-code"));
+        assert!(!cli_needs_explicit_submit("droid"));
+    }
+
+    #[test]
+    fn claude_code_detected_case_insensitively() {
+        assert!(cli_is_claude_code("claude-code"));
+        assert!(cli_is_claude_code("Claude-Code"));
+        assert!(cli_is_claude_code("cli-claude-code-sonnet"));
+        assert!(!cli_is_claude_code("codex"));
+        assert!(!cli_is_claude_code("claude")); // must be the full "claude-code" marker
+    }
+
+    #[test]
+    fn initial_schedule_matches_cli() {
+        // Codex: three spaced Enters — the key fix for the composer-not-submitting bug.
+        assert_eq!(initial_submit_keystroke_schedule_ms("codex"), &[120, 360, 900]);
+        assert_eq!(
+            initial_submit_keystroke_schedule_ms("cli-codex-123"),
+            &[120, 360, 900]
+        );
+        // Claude Code: one cold-start safety Enter.
+        assert_eq!(initial_submit_keystroke_schedule_ms("claude-code"), &[420]);
+        // Others: none — the instruction's own trailing CR submits it.
+        assert_eq!(
+            initial_submit_keystroke_schedule_ms("droid"),
+            &[] as &[u64]
+        );
+        assert_eq!(
+            initial_submit_keystroke_schedule_ms("opencode"),
+            &[] as &[u64]
+        );
+    }
+
+    #[test]
+    fn followup_schedule_only_for_codex() {
+        assert_eq!(
+            followup_submit_keystroke_schedule_ms("codex"),
+            &[120, 360, 900]
+        );
+        // Claude Code gets no follow-up Enter (its safety Enter is initial-only).
+        assert_eq!(
+            followup_submit_keystroke_schedule_ms("claude-code"),
+            &[] as &[u64]
+        );
+        assert_eq!(
+            followup_submit_keystroke_schedule_ms("droid"),
+            &[] as &[u64]
+        );
+    }
+}

--- a/frontend/src/components/ui-new/containers/WorkspacesSidebarContainer.tsx
+++ b/frontend/src/components/ui-new/containers/WorkspacesSidebarContainer.tsx
@@ -12,7 +12,8 @@ import { WorkspacesSidebar } from '@/components/ui-new/views/WorkspacesSidebar';
 import { useConciergeSessions, conciergeKeys } from '@/hooks/useConcierge';
 import { useQueryClient } from '@tanstack/react-query';
 import { conciergeApi } from '@/lib/conciergeApi';
-import { usePlanningDrafts } from '@/hooks/usePlanningDraft';
+import { planningDraftsApi } from '@/lib/api';
+import { usePlanningDrafts, planningDraftKeys } from '@/hooks/usePlanningDraft';
 import type { Workspace } from '@/components/ui-new/hooks/useWorkspaces';
 
 // Fixed UUID for the universal workspace draft (same as in useCreateModeState.ts)
@@ -105,6 +106,10 @@ export function WorkspacesSidebarContainer() {
       const sessionId = id.slice(10);
       await conciergeApi.deleteSession(sessionId);
       queryClient.invalidateQueries({ queryKey: conciergeKeys.sessions() });
+    } else if (id.startsWith('draft-')) {
+      const draftId = id.slice(6);
+      await planningDraftsApi.deleteDraft(draftId);
+      queryClient.invalidateQueries({ queryKey: planningDraftKeys.all });
     }
   }, [queryClient]);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -732,6 +732,14 @@ export const planningDraftsApi = {
     return handleApiResponse<PlanningDraftResponse>(response);
   },
 
+  /** Hard-delete a planning draft (an orchestrated-workspace conversation). */
+  deleteDraft: async (draftId: string): Promise<void> => {
+    const response = await makeRequest(`/api/planning-drafts/${draftId}`, {
+      method: 'DELETE',
+    });
+    return handleApiResponse<void>(response);
+  },
+
   toggleFeishuSync: async (
     draftId: string,
     data: { enabled: boolean; syncHistory: boolean; chatId?: string }


### PR DESCRIPTION
## Summary

Fixes two user-reported bugs:

1. **Orchestrated-workspace conversations could not be deleted.** In the workspaces sidebar, the three-dots (⋯) control on an orchestrated-workspace conversation (a planning *draft*) did nothing when clicked.
2. **Codex (and any non-Claude CLI) stalled in manual-workflow (DIY) mode.** The terminal launched, finished initializing (~30–40 s), then sat idle instead of starting the task — the injected instruction was never submitted.

## Issue 1 — draft delete no-op

**Root cause.** The sidebar *view* wired `onDelete` for both `concierge-` and `draft-` conversation ids, but:
- the container's `handleDeleteWorkspace` only had a `concierge-` branch (drafts fell through to a silent no-op), and
- there was no backend route to delete a planning draft.

So the button was live but its handler did nothing for drafts.

**Fix.**
- `PlanningDraft::delete` (db): detaches child rounds via the self-referential `parent_draft_id` FK (no cascade there) and lets `planning_draft_message` rows cascade; a materialized draft's workflow is left intact (`ON DELETE SET NULL` from the workflow side). Covered by a new test.
- `DELETE /api/planning-drafts/{id}` (server): best-effort, path-safe audit-doc file cleanup mirroring `delete_audit_doc`, then the DB delete.
- Frontend: `planningDraftsApi.deleteDraft` + a `draft-` branch in `handleDeleteWorkspace` that invalidates the drafts query so the row disappears immediately.

**Note on "archive".** The ⋯ control is a **delete** action (its tooltip is "Delete"); there is no archive capability for these ephemeral planning conversations, and there never was a menu offering one. This PR restores the delete path. Adding archive would require a schema field + routes + list-filter + a menu UI — a separate feature, out of scope for this bug.

## Issue 2 — non-CC CLI prompt not submitted in DIY mode

**Root cause.** After pasting the task instruction into the terminal, the DIY dispatcher (`start_workflow`) sent a **single** generic Enter for every CLI. Claude Code submits on the instruction's own trailing carriage return, so it worked. **Codex** keeps pasted text in its composer until it receives several explicit Enters (cold-start TUI frames can swallow the first one or two), so a single Enter left the prompt sitting unsubmitted — "initialised, then did nothing". The orchestrator (agent-planned) path already sent Codex a `[120, 360, 900] ms` Enter schedule; the DIY path never replicated it.

**Fix.**
- New `terminal::submit_policy` module — the single source of truth for per-CLI submit keystrokes: Codex `[120,360,900]`, Claude Code initial-dispatch `[420]`, everything else none (their payload's own trailing `\r` submits). Unit-tested.
- The orchestrator now **delegates** to this policy (behavior-preserving refactor — identical schedules, just relocated).
- The DIY instruction dispatch and slash-command dispatch both drive submission through the same policy, so DIY and agent-planned modes coax each CLI identically.

Claude Code was re-checked: its DIY behavior is unchanged (initial instruction still gets exactly one submit Enter; the redundant second Enter previously sent after slash-command prompts is removed to match the orchestrator).

## Test results

Local — mirrors the `ci-basic` backend + frontend jobs exactly:
- `cargo build --workspace --exclude solodawn-tray --profile ci --tests` — ✅
- `cargo clippy --workspace --exclude solodawn-tray --all-targets --all-features --profile ci -- -D warnings` — ✅
- `cargo nextest run --workspace --exclude solodawn-tray --cargo-profile ci --lib` — ✅
- `cargo run --bin generate_types --profile ci -- --check` — ✅
- Frontend `tsc --noEmit`, `eslint`, `vitest run` — ✅

---

## 中文摘要

修复两个用户反馈的问题：

1. **编排工作区的对话无法删除。** 侧边栏中编排工作区对话（planning draft）的三点（⋯）按钮点击无反应——视图为 `draft-` 绑定了 `onDelete`，但容器的 `handleDeleteWorkspace` 只处理 `concierge-`，且后端没有删除 planning draft 的路由。已补齐 `PlanningDraft::delete`（含测试）、`DELETE /api/planning-drafts/{id}` 路由，以及前端 `deleteDraft` 与 `draft-` 分支。⋯ 按钮本身是「删除」操作（tooltip 为 Delete），这类临时规划对话没有「归档」功能，本次恢复删除能力。
2. **手动工作流（DIY）模式下 Codex 等非 CC 的 CLI 卡住。** DIY 派发指令后对所有 CLI 只发一个通用回车；CC 靠指令自带的 `\r` 提交，正常，但 Codex 的 TUI 会把粘贴文本留在输入框里，需要多次显式回车（冷启动帧可能吞掉前一两次），所以提示词一直没提交——「初始化完成后就没动静」。编排（agent-planned）路径本就有 Codex 的 `[120,360,900]ms` 回车序列，DIY 路径没有复制。新增 `terminal::submit_policy` 作为各 CLI 提交按键的唯一真源，编排路径改为委托（行为不变），DIY 路径也走同一策略，两种模式对每个 CLI 的驱动方式一致。CC 已复查，行为不变。
