### PR TITLE
fix(ui): expose a Resume entry for paused workflows

### DIFF
--- a/frontend/src/components/pipeline/OrchestratorHeader.test.tsx
+++ b/frontend/src/components/pipeline/OrchestratorHeader.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('react-i18next', () => ({
@@ -7,6 +8,10 @@ vi.mock('react-i18next', () => ({
       const translations: Record<string, string> = {
         'pipeline.orchestrator.statusLabel': 'Status:',
         'pipeline.orchestrator.modelLabel': 'Model:',
+        'pipeline.orchestrator.resume': 'Resume',
+        'pipeline.orchestrator.resuming': 'Resuming...',
+        'pipeline.orchestrator.pausedHint':
+          'Execution is paused — resume to continue.',
       };
       return translations[key] ?? key;
     },
@@ -22,5 +27,74 @@ describe('OrchestratorHeader', () => {
     expect(screen.getByText('Workflow X')).toBeInTheDocument();
     expect(screen.getByText(/status: running/i)).toBeInTheDocument();
     expect(screen.getByText(/model: gpt-4o/i)).toBeInTheDocument();
+  });
+
+  it('hides the resume action when the workflow is not resumable', () => {
+    render(
+      <OrchestratorHeader
+        name="Workflow X"
+        status="running"
+        model="gpt-4o"
+        canResume={false}
+        onResume={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /resume/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a resume action with a paused hint when resumable', async () => {
+    const onResume = vi.fn();
+    render(
+      <OrchestratorHeader
+        name="Workflow X"
+        status="paused"
+        model="gpt-4o"
+        canResume
+        onResume={onResume}
+      />
+    );
+
+    expect(
+      screen.getByText('Execution is paused — resume to continue.')
+    ).toBeInTheDocument();
+
+    const button = screen.getByRole('button', { name: 'Resume' });
+    expect(button).toBeEnabled();
+
+    await userEvent.click(button);
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the resume action and shows progress while resuming', () => {
+    render(
+      <OrchestratorHeader
+        name="Workflow X"
+        status="paused"
+        model="gpt-4o"
+        canResume
+        isResuming
+        onResume={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Resuming...' })).toBeDisabled();
+  });
+
+  it('omits the resume action when no handler is supplied', () => {
+    render(
+      <OrchestratorHeader
+        name="Workflow X"
+        status="paused"
+        model="gpt-4o"
+        canResume
+      />
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /resume/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/pipeline/OrchestratorHeader.tsx
+++ b/frontend/src/components/pipeline/OrchestratorHeader.tsx
@@ -1,21 +1,54 @@
 import { useTranslation } from 'react-i18next';
+import { Play } from 'lucide-react';
+import { Button } from '@/components/ui-new/primitives/Button';
 
 interface OrchestratorHeaderProps {
   name: string;
   status: string;
   model: string | null;
+  /**
+   * True when the workflow is `paused` and can be resumed. A workflow lands
+   * here either because the user paused it or because restart recovery
+   * auto-paused it (the backend never auto-fails on a restart artifact), so
+   * this header is the only place the user can get execution going again.
+   */
+  canResume?: boolean;
+  isResuming?: boolean;
+  onResume?: () => void;
 }
 
-export function OrchestratorHeader({ name, status, model }: Readonly<OrchestratorHeaderProps>) {
+export function OrchestratorHeader({
+  name,
+  status,
+  model,
+  canResume = false,
+  isResuming = false,
+  onResume,
+}: Readonly<OrchestratorHeaderProps>) {
   const { t } = useTranslation('workflow');
+  const showResume = canResume && Boolean(onResume);
+
   return (
-    <div className="h-16 bg-panel border-b border-border px-6 flex items-center">
-      <div className="flex-1">
+    <div className="h-16 bg-panel border-b border-border px-6 flex items-center gap-4">
+      <div className="flex-1 min-w-0">
         <div className="text-lg font-semibold">{name}</div>
         <div className="text-xs text-low">
           {t('pipeline.orchestrator.statusLabel')} {status} | {t('pipeline.orchestrator.modelLabel')} {model ?? 'n/a'}
         </div>
       </div>
+      {showResume && (
+        <div className="flex items-center gap-3">
+          <span className="hidden text-xs text-low sm:inline">
+            {t('pipeline.orchestrator.pausedHint')}
+          </span>
+          <Button size="sm" onClick={onResume} disabled={isResuming}>
+            <Play className="w-3.5 h-3.5" />
+            {isResuming
+              ? t('pipeline.orchestrator.resuming')
+              : t('pipeline.orchestrator.resume')}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/useWorkflows.test.tsx
+++ b/frontend/src/hooks/useWorkflows.test.tsx
@@ -28,8 +28,10 @@ import {
   useDeleteWorkflow,
   getWorkflowActions,
   workflowKeys,
+  WORKFLOW_STATUS_TRANSITIONS,
   type Workflow,
   type CreateWorkflowRequest,
+  type WorkflowStatusEnum,
 } from './useWorkflows';
 
 // ============================================================================
@@ -541,5 +543,39 @@ describe('getWorkflowActions', () => {
     expect(getWorkflowActions('running').canMerge).toBe(false);
     expect(getWorkflowActions('cancelled').canMerge).toBe(false);
     expect(getWorkflowActions('draft').canMerge).toBe(false);
+  });
+
+  // A workflow reaches `paused` either from an explicit user pause or from
+  // restart recovery auto-pausing an interrupted run. Both need a resume entry
+  // in the UI, and neither should be presented as a fresh "start".
+  it('should offer resume, not start, for paused workflows', () => {
+    const actions = getWorkflowActions('paused');
+
+    expect(actions.canResume).toBe(true);
+    expect(actions.canStart).toBe(false);
+    expect(actions.canPrepare).toBe(false);
+  });
+
+  it('should keep paused workflows stoppable and deletable', () => {
+    const actions = getWorkflowActions('paused');
+
+    expect(actions.canStop).toBe(true);
+    expect(actions.canDelete).toBe(true);
+    expect(actions.canPause).toBe(false);
+  });
+
+  it('should offer start, not resume, for ready workflows', () => {
+    const actions = getWorkflowActions('ready');
+
+    expect(actions.canStart).toBe(true);
+    expect(actions.canResume).toBe(false);
+  });
+
+  it('should expose resume for the paused status only', () => {
+    const resumable = (
+      Object.keys(WORKFLOW_STATUS_TRANSITIONS) as WorkflowStatusEnum[]
+    ).filter((status) => WORKFLOW_STATUS_TRANSITIONS[status].canResume);
+
+    expect(resumable).toEqual(['paused']);
   });
 });

--- a/frontend/src/hooks/useWorkflows.ts
+++ b/frontend/src/hooks/useWorkflows.ts
@@ -51,6 +51,7 @@ export type WorkflowStatusEnum = BackendWorkflowStatus | 'draft';
 export interface WorkflowActions {
   canPrepare: boolean; // created → starting → ready (启动终端)
   canStart: boolean; // ready → running (开始任务)
+  canResume: boolean; // paused → running (恢复执行)
   canPause: boolean;
   canStop: boolean;
   canMerge: boolean;
@@ -64,6 +65,7 @@ export const WORKFLOW_STATUS_TRANSITIONS: Record<
   draft: {
     canPrepare: false,
     canStart: false,
+    canResume: false,
     canPause: false,
     canStop: false,
     canMerge: false,
@@ -72,6 +74,7 @@ export const WORKFLOW_STATUS_TRANSITIONS: Record<
   created: {
     canPrepare: true,
     canStart: false,
+    canResume: false,
     canPause: false,
     canStop: false,
     canMerge: false,
@@ -80,6 +83,7 @@ export const WORKFLOW_STATUS_TRANSITIONS: Record<
   ready: {
     canPrepare: false,
     canStart: true,
+    canResume: false,
     canPause: false,
     canStop: false,
     canMerge: false,
@@ -88,6 +92,7 @@ export const WORKFLOW_STATUS_TRANSITIONS: Record<
   starting: {
     canPrepare: false,
     canStart: false,
+    canResume: false,
     canPause: false,
     canStop: true,
     canMerge: false,
@@ -96,14 +101,21 @@ export const WORKFLOW_STATUS_TRANSITIONS: Record<
   running: {
     canPrepare: false,
     canStart: false,
+    canResume: false,
     canPause: true,
     canStop: true,
     canMerge: false,
     canDelete: false,
   },
+  // A paused workflow (user-initiated pause, or auto-paused by restart
+  // recovery — see `recover_running_workflows`) is resumable, not startable:
+  // it already has tasks/terminals, so the UI must offer "Resume", never
+  // "Start". Both funnel into POST /api/workflows/{id}/start, which accepts
+  // `paused` and CASes it back to `ready` before re-driving the agent.
   paused: {
     canPrepare: false,
-    canStart: true,
+    canStart: false,
+    canResume: true,
     canPause: false,
     canStop: true,
     canMerge: false,
@@ -112,6 +124,7 @@ export const WORKFLOW_STATUS_TRANSITIONS: Record<
   merging: {
     canPrepare: false,
     canStart: false,
+    canResume: false,
     canPause: false,
     canStop: false,
     canMerge: false,
@@ -120,6 +133,7 @@ export const WORKFLOW_STATUS_TRANSITIONS: Record<
   completed: {
     canPrepare: false,
     canStart: false,
+    canResume: false,
     canPause: false,
     canStop: false,
     canMerge: true,
@@ -128,6 +142,7 @@ export const WORKFLOW_STATUS_TRANSITIONS: Record<
   failed: {
     canPrepare: true,
     canStart: false,
+    canResume: false,
     canPause: false,
     canStop: false,
     canMerge: false,
@@ -136,6 +151,7 @@ export const WORKFLOW_STATUS_TRANSITIONS: Record<
   cancelled: {
     canPrepare: false,
     canStart: false,
+    canResume: false,
     canPause: false,
     canStop: false,
     canMerge: false,

--- a/frontend/src/i18n/locales/en/workflow.json
+++ b/frontend/src/i18n/locales/en/workflow.json
@@ -404,7 +404,10 @@
     "hint": "Click on a terminal to view details",
     "orchestrator": {
       "statusLabel": "Status:",
-      "modelLabel": "Model:"
+      "modelLabel": "Model:",
+      "resume": "Resume",
+      "resuming": "Resuming...",
+      "pausedHint": "Execution is paused — resume to continue."
     }
   },
   "terminalCard": {
@@ -505,6 +508,8 @@
       "prepare": "Prepare Workflow",
       "preparing": "Preparing...",
       "start": "Start Workflow",
+      "resume": "Resume Workflow",
+      "resuming": "Resuming...",
       "pause": "Pause",
       "stop": "Stop",
       "merge": "Merge Workflow",

--- a/frontend/src/i18n/locales/es/workflow.json
+++ b/frontend/src/i18n/locales/es/workflow.json
@@ -404,7 +404,10 @@
     "hint": "Click on a terminal to view details",
     "orchestrator": {
       "statusLabel": "Status:",
-      "modelLabel": "Model:"
+      "modelLabel": "Model:",
+      "resume": "Resume",
+      "resuming": "Resuming...",
+      "pausedHint": "Execution is paused — resume to continue."
     }
   },
   "terminalCard": {
@@ -505,6 +508,8 @@
       "prepare": "Prepare Workflow",
       "preparing": "Preparing...",
       "start": "Start Workflow",
+      "resume": "Resume Workflow",
+      "resuming": "Resuming...",
       "pause": "Pause",
       "stop": "Stop",
       "merge": "Merge Workflow",

--- a/frontend/src/i18n/locales/ja/workflow.json
+++ b/frontend/src/i18n/locales/ja/workflow.json
@@ -404,7 +404,10 @@
     "hint": "Click on a terminal to view details",
     "orchestrator": {
       "statusLabel": "Status:",
-      "modelLabel": "Model:"
+      "modelLabel": "Model:",
+      "resume": "Resume",
+      "resuming": "Resuming...",
+      "pausedHint": "Execution is paused — resume to continue."
     }
   },
   "terminalCard": {
@@ -505,6 +508,8 @@
       "prepare": "Prepare Workflow",
       "preparing": "Preparing...",
       "start": "Start Workflow",
+      "resume": "Resume Workflow",
+      "resuming": "Resuming...",
       "pause": "Pause",
       "stop": "Stop",
       "merge": "Merge Workflow",

--- a/frontend/src/i18n/locales/ko/workflow.json
+++ b/frontend/src/i18n/locales/ko/workflow.json
@@ -404,7 +404,10 @@
     "hint": "Click on a terminal to view details",
     "orchestrator": {
       "statusLabel": "Status:",
-      "modelLabel": "Model:"
+      "modelLabel": "Model:",
+      "resume": "Resume",
+      "resuming": "Resuming...",
+      "pausedHint": "Execution is paused — resume to continue."
     }
   },
   "terminalCard": {
@@ -505,6 +508,8 @@
       "prepare": "Prepare Workflow",
       "preparing": "Preparing...",
       "start": "Start Workflow",
+      "resume": "Resume Workflow",
+      "resuming": "Resuming...",
       "pause": "Pause",
       "stop": "Stop",
       "merge": "Merge Workflow",

--- a/frontend/src/i18n/locales/zh-Hans/workflow.json
+++ b/frontend/src/i18n/locales/zh-Hans/workflow.json
@@ -407,7 +407,10 @@
     "hint": "点击终端查看详情",
     "orchestrator": {
       "statusLabel": "状态：",
-      "modelLabel": "模型："
+      "modelLabel": "模型：",
+      "resume": "恢复执行",
+      "resuming": "恢复中...",
+      "pausedHint": "工作流已暂停，点击恢复执行以继续。"
     }
   },
   "terminalCard": {
@@ -508,6 +511,8 @@
       "prepare": "预处理工作流",
       "preparing": "预处理中...",
       "start": "启动工作流",
+      "resume": "恢复执行",
+      "resuming": "恢复中...",
       "pause": "暂停",
       "stop": "停止",
       "merge": "合并工作流",

--- a/frontend/src/i18n/locales/zh-Hant/workflow.json
+++ b/frontend/src/i18n/locales/zh-Hant/workflow.json
@@ -404,7 +404,10 @@
     "hint": "Click on a terminal to view details",
     "orchestrator": {
       "statusLabel": "Status:",
-      "modelLabel": "Model:"
+      "modelLabel": "Model:",
+      "resume": "Resume",
+      "resuming": "Resuming...",
+      "pausedHint": "Execution is paused — resume to continue."
     }
   },
   "terminalCard": {
@@ -505,6 +508,8 @@
       "prepare": "Prepare Workflow",
       "preparing": "Preparing...",
       "start": "Start Workflow",
+      "resume": "Resume Workflow",
+      "resuming": "Resuming...",
       "pause": "Pause",
       "stop": "Stop",
       "merge": "Merge Workflow",

--- a/frontend/src/pages/Pipeline.test.tsx
+++ b/frontend/src/pages/Pipeline.test.tsx
@@ -1,43 +1,120 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { Pipeline } from './Pipeline';
 
-vi.mock('@/hooks/useWorkflows', () => ({
-  useWorkflow: vi.fn(),
-}));
+// Keep the real status→actions table so the resume wiring is exercised against
+// the same transition rules the app ships with; only the data/mutation hooks
+// are stubbed.
+vi.mock('@/hooks/useWorkflows', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/hooks/useWorkflows')>();
+  return {
+    getWorkflowActions: actual.getWorkflowActions,
+    useWorkflow: vi.fn(),
+    useStartWorkflow: vi.fn(),
+  };
+});
 
 vi.mock('@/hooks/useWorkflowInvalidation', () => ({
   useWorkflowInvalidation: vi.fn(),
 }));
 
 vi.mock('@/components/pipeline/OrchestratorHeader', () => ({
-  OrchestratorHeader: () => <div data-testid="orchestrator-header" />,
+  OrchestratorHeader: ({
+    canResume,
+    isResuming,
+    onResume,
+  }: {
+    canResume?: boolean;
+    isResuming?: boolean;
+    onResume?: () => void;
+  }) => (
+    <div data-testid="orchestrator-header">
+      <span data-testid="can-resume">{String(canResume)}</span>
+      <span data-testid="is-resuming">{String(isResuming)}</span>
+      <button type="button" onClick={onResume}>
+        resume
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('@/components/pipeline/TaskPipeline', () => ({
   TaskPipeline: () => <div data-testid="task-pipeline" />,
 }));
 
-import { useWorkflow } from '@/hooks/useWorkflows';
+import { useStartWorkflow, useWorkflow } from '@/hooks/useWorkflows';
+
+function renderPipeline() {
+  return render(
+    <MemoryRouter initialEntries={['/pipeline/wf-1']}>
+      <Routes>
+        <Route path="/pipeline/:workflowId" element={<Pipeline />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function mockWorkflow(status: string) {
+  vi.mocked(useWorkflow).mockReturnValue({
+    data: { name: 'Workflow X', status, orchestratorModel: 'gpt-4o' },
+    isLoading: false,
+    error: null,
+  } as never);
+}
 
 describe('Pipeline page', () => {
-  it('renders header and pipeline when data exists', () => {
-    vi.mocked(useWorkflow).mockReturnValue({
-      data: { name: 'Workflow X', status: 'running', orchestratorModel: 'gpt-4o' },
-      isLoading: false,
-      error: null,
-    } as any);
+  const mutate = vi.fn();
 
-    render(
-      <MemoryRouter initialEntries={['/pipeline/wf-1']}>
-        <Routes>
-          <Route path="/pipeline/:workflowId" element={<Pipeline />} />
-        </Routes>
-      </MemoryRouter>
-    );
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useStartWorkflow).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as never);
+  });
+
+  it('renders header and pipeline when data exists', () => {
+    mockWorkflow('running');
+    renderPipeline();
 
     expect(screen.getByTestId('orchestrator-header')).toBeInTheDocument();
     expect(screen.getByTestId('task-pipeline')).toBeInTheDocument();
+  });
+
+  it('does not offer resume while the workflow is running', () => {
+    mockWorkflow('running');
+    renderPipeline();
+
+    expect(screen.getByTestId('can-resume')).toHaveTextContent('false');
+  });
+
+  it('offers resume for a paused workflow', () => {
+    mockWorkflow('paused');
+    renderPipeline();
+
+    expect(screen.getByTestId('can-resume')).toHaveTextContent('true');
+  });
+
+  it('resumes a paused workflow through the start mutation', async () => {
+    mockWorkflow('paused');
+    renderPipeline();
+
+    await userEvent.click(screen.getByRole('button', { name: 'resume' }));
+
+    expect(mutate).toHaveBeenCalledWith({ workflow_id: 'wf-1' });
+  });
+
+  it('reports in-flight resume state to the header', () => {
+    vi.mocked(useStartWorkflow).mockReturnValue({
+      mutate,
+      isPending: true,
+    } as never);
+    mockWorkflow('paused');
+    renderPipeline();
+
+    expect(screen.getByTestId('is-resuming')).toHaveTextContent('true');
   });
 });

--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -1,5 +1,11 @@
+import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import { useWorkflow } from '@/hooks/useWorkflows';
+import {
+  getWorkflowActions,
+  useStartWorkflow,
+  useWorkflow,
+  type WorkflowStatusEnum,
+} from '@/hooks/useWorkflows';
 import { useWorkflowInvalidation } from '@/hooks/useWorkflowInvalidation';
 import { OrchestratorHeader } from '@/components/pipeline/OrchestratorHeader';
 import { TaskPipeline } from '@/components/pipeline/TaskPipeline';
@@ -11,8 +17,19 @@ export function Pipeline() {
   // Guard: hook internally no-ops when workflowId is undefined
   useWorkflowInvalidation(workflowId);
 
+  // Resume goes through POST /api/workflows/{id}/start: that endpoint accepts
+  // `paused` and CASes it back to `ready` before re-driving the runtime, and it
+  // is the only start path that also covers DIY (non-orchestrator) workflows.
+  const { mutate: startWorkflow, isPending: isResuming } = useStartWorkflow();
+  const handleResume = useCallback(() => {
+    if (!workflowId) return;
+    startWorkflow({ workflow_id: workflowId });
+  }, [startWorkflow, workflowId]);
+
   if (isLoading) return <div className="p-6 text-low">Loading...</div>;
   if (!workflow) return <div className="p-6 text-low">Workflow not found</div>;
+
+  const actions = getWorkflowActions(workflow.status as WorkflowStatusEnum);
 
   return (
     <div className="flex h-screen flex-col bg-primary">
@@ -20,6 +37,9 @@ export function Pipeline() {
         name={workflow.name}
         status={workflow.status}
         model={workflow.orchestratorModel}
+        canResume={actions.canResume}
+        isResuming={isResuming}
+        onResume={handleResume}
       />
       <TaskPipeline workflowId={workflowId ?? ''} />
     </div>

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -275,6 +275,20 @@ function WorkflowDetailActions({
           {t('management.actions.start')}
         </Button>
       )}
+      {/* Paused workflows resume through the same start endpoint, but must be
+          labelled as a resume: the run already has tasks/terminals and may have
+          been auto-paused by restart recovery rather than by the user. */}
+      {actions.canResume && (
+        <Button
+          onClick={() => handlers.onStart(workflowId)}
+          disabled={mutations.anyPending}
+        >
+          <Play className="w-4 h-4 mr-2" />
+          {mutations.startPending
+            ? t('management.actions.resuming')
+            : t('management.actions.resume')}
+        </Button>
+      )}
       {actions.canPause && (
         <Button
           variant="outline"


### PR DESCRIPTION
## Problem

After a dev/service restart, SoloDawn auto-pauses any workflow that was `running`. That part is correct — `recover_running_workflows` deliberately never auto-fails on a restart artifact (R7-PB1). But the UI gave the user no way back:

- **`/pipeline/{workflowId}`** — the page a user actually lands on for a workflow — rendered only `name / status / model` text. `OrchestratorHeader` had **no action controls at all**, so a paused workflow was a dead end. Terminals sit at "waiting" and nothing advances.
- **`/workflows`** management detail did surface an action for `paused`, but mapped it onto `canStart` and labelled it **"Start Workflow"** — the wrong verb for a run that already has tasks, terminals and branches.

The backend was never the problem: `POST /api/workflows/{id}/start` already accepts `paused`, CASes it back to `ready` and re-drives the runtime. Only the UI entry was missing.

## Fix

| File | Change |
|---|---|
| `hooks/useWorkflows.ts` | Split `canResume` out of `canStart`. `paused` is now resumable-not-startable; it is the only status with `canResume`. |
| `components/pipeline/OrchestratorHeader.tsx` | New optional `canResume` / `isResuming` / `onResume` props → labelled **Resume** button + a paused hint. Stays stateless. |
| `pages/Pipeline.tsx` | Owns the mutation, derives `canResume` from the real transition table, passes the handler down. |
| `pages/Workflows.tsx` | `WorkflowDetailActions` renders a distinct **Resume Workflow** button for `canResume`. |
| `i18n/locales/*/workflow.json` | `resume` / `resuming` / `pausedHint` keys across all six locales (Chinese translated in `zh-Hans`, English placeholders elsewhere, matching this namespace's existing state). |

After clicking Resume: the mutation optimistically flips the workflow to `running`, invalidates the detail + list queries on settle, and `useWorkflowInvalidation` (already mounted on the pipeline page) refreshes task and terminal state from the `task.status_changed` / `terminal.status_changed` WS events as the runtime re-drives them.

### Why `/start` and not `/resume`

There is a dedicated `POST /api/workflows/{id}/resume` whose doc comment says it exists so the frontend can show a Resume button. It is deliberately **not** used here:

1. It unconditionally calls `orchestrator_runtime().resume_workflow()`, which would create an orchestrator agent for a **DIY** workflow that should never have one.
2. Its `needs_reprepare` check treats any non-`waiting` terminal as broken, so after a restart (all terminals reconciled to `not_started`) it force-launches every PTY through `prepare_workflow` — duplicating work the orchestrator agent's cap-aware queue already does for `not_started` terminals (`agent.rs`, dispatch loop).

`/start` handles both execution modes, tolerates queued `not_started` terminals, and is the path already verified to recover restart-paused workflows in the field. `/resume` is left untouched.

## Verification

Ran the three commands `frontend-check` runs in CI, locally:

- `pnpm run check` (`tsc --noEmit`) — exit 0
- `pnpm run lint` (eslint, `--max-warnings 0`) — exit 0
- `pnpm test:run` — **76 files / 529 tests passed**

New/updated tests:

- `OrchestratorHeader.test.tsx` — resume hidden when not resumable, hidden when no handler, rendered with hint when paused, fires the callback, and disabled + "Resuming..." while in flight.
- `Pipeline.test.tsx` — resume wiring exercised against the **real** `getWorkflowActions` table: absent for `running`, present for `paused`, dispatches `{ workflow_id }`, and reports in-flight state.
- `useWorkflows.test.tsx` — `paused` yields resume-not-start, stays stoppable/deletable, `ready` yields start-not-resume, and `paused` is the only status exposing `canResume`.

Frontend-only change, so `backend-check` is skipped by the path filter.

## Notes

Prettier reports all seven touched files as unformatted — that drift is **pre-existing on `main`** (verified by running `prettier --check` against the `HEAD` versions), and `format:check` is not a CI gate, so it is left alone rather than bundling a large unrelated reformat into this fix.

Closes the "服务重启后工作流自动暂停，但 UI 没有恢复执行入口" report.
