### PR TITLE
refactor(server): remove dead POST /workflows/{id}/resume endpoint

### DIFF
--- a/crates/db/src/models/workflow.rs
+++ b/crates/db/src/models/workflow.rs
@@ -710,30 +710,6 @@ impl Workflow {
         Ok(())
     }
 
-    /// Atomically transition workflow from 'paused' to 'created' (CAS).
-    ///
-    /// CORE-019: Used by the resume-flow re-prepare path. Returning `Ok(false)`
-    /// (rather than an error) signals that the workflow was no longer in the
-    /// 'paused' state when the UPDATE executed — e.g. a concurrent stop/cancel
-    /// raced ahead. The caller MUST treat `false` as a conflict and abort the
-    /// re-prepare instead of proceeding with a non-CAS write.
-    pub async fn set_created_from_paused(pool: &SqlitePool, id: &str) -> sqlx::Result<bool> {
-        let now = Utc::now();
-        let result = sqlx::query(
-            r"
-            UPDATE workflow
-            SET status = 'created', updated_at = ?
-            WHERE id = ? AND status = 'paused'
-            ",
-        )
-        .bind(now)
-        .bind(id)
-        .execute(pool)
-        .await?;
-
-        Ok(result.rows_affected() > 0)
-    }
-
     /// Set workflow to ready (only from 'starting' state).
     ///
     /// Uses CAS to ensure workflow is in 'starting' state before transitioning

--- a/crates/server/src/routes/workflows.rs
+++ b/crates/server/src/routes/workflows.rs
@@ -175,7 +175,6 @@ pub fn workflows_routes() -> Router<DeploymentImpl> {
         .route("/{workflow_id}/prepare", post(prepare_workflow))
         .route("/{workflow_id}/start", post(start_workflow))
         .route("/{workflow_id}/pause", post(pause_workflow))
-        .route("/{workflow_id}/resume", post(resume_workflow))
         .route("/{workflow_id}/stop", post(stop_workflow))
         .route(
             "/{workflow_id}/prompts/respond",
@@ -2646,129 +2645,6 @@ async fn pause_workflow(
         workflow_id = %workflow_id,
         "Workflow paused with terminal cleanup and cascaded status updates"
     );
-
-    Ok(ResponseJson(ApiResponse::success(())))
-}
-
-/// POST /api/workflows/:workflow_id/resume
-/// Resume a paused workflow (G05-002)
-///
-/// Transitions the workflow from paused to ready via CAS and then starts
-/// the orchestrator runtime. This endpoint provides a dedicated resume path
-/// rather than reusing the start endpoint, giving clearer semantics and
-/// enabling the frontend to show a distinct Resume button.
-async fn resume_workflow(
-    State(deployment): State<DeploymentImpl>,
-    Path(workflow_id): Path<Uuid>,
-) -> Result<ResponseJson<ApiResponse<()>>, ApiError> {
-    let workflow_id = workflow_id.to_string();
-
-    // Verify workflow exists and is in paused state
-    let workflow = Workflow::find_by_id(&deployment.db().pool, &workflow_id)
-        .await?
-        .ok_or_else(|| ApiError::NotFound("Workflow not found".to_string()))?;
-
-    if workflow.status != WORKFLOW_STATUS_PAUSED {
-        return Err(ApiError::BadRequest(format!(
-            "Cannot resume workflow: current status is '{}', expected 'paused'",
-            workflow.status
-        )));
-    }
-
-    // Check terminal readiness before resuming (mirrors start_workflow self-heal logic)
-    {
-        let terminals =
-            db::models::Terminal::find_by_workflow(&deployment.db().pool, &workflow_id).await?;
-
-        let needs_reprepare = terminals.iter().any(|terminal| {
-            terminal.status != "waiting"
-                || terminal
-                    .pty_session_id
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|session| !session.is_empty())
-                    .is_none()
-        });
-
-        if needs_reprepare {
-            tracing::warn!(
-                workflow_id = %workflow_id,
-                "Workflow terminals are not launch-ready; re-preparing before resume"
-            );
-
-            // CORE-019: Use a CAS update (paused -> created) so a concurrent
-            // stop/cancel that changed the status away from 'paused' is
-            // detected here instead of being silently overwritten. If 0 rows
-            // were affected, the workflow is no longer 'paused' — return a
-            // Conflict error and do NOT call prepare_workflow, which would
-            // otherwise act on stale state.
-            let cas_succeeded = Workflow::set_created_from_paused(
-                &deployment.db().pool,
-                &workflow_id,
-            )
-            .await
-            .map_err(|e| {
-                ApiError::Internal(format!(
-                    "Resume-phase CAS status update failed for workflow {workflow_id}: {e}"
-                ))
-            })?;
-
-            if !cas_succeeded {
-                return Err(ApiError::Conflict(format!(
-                    "Workflow {workflow_id} is no longer 'paused' (likely modified by a concurrent \
-                     stop/cancel); aborting resume re-prepare"
-                )));
-            }
-
-            let _ = prepare_workflow(
-                State(deployment.clone()),
-                Path(
-                    Uuid::parse_str(&workflow_id)
-                        .map_err(|e| ApiError::BadRequest(format!("Invalid workflow ID: {e}")))?,
-                ),
-            )
-            .await
-            .map_err(|e| {
-                ApiError::Internal(format!(
-                    "Resume-phase re-prepare failed for workflow {workflow_id}: {e}"
-                ))
-            })?;
-
-            // Verify workflow status is back to "ready" after re-prepare, then
-            // transition to paused so the runtime resume CAS (paused -> ready) succeeds.
-            let refreshed = Workflow::find_by_id(&deployment.db().pool, &workflow_id)
-                .await?
-                .ok_or_else(|| ApiError::NotFound("Workflow not found".to_string()))?;
-
-            if refreshed.status != "ready" {
-                return Err(ApiError::Internal(format!(
-                    "Re-prepare did not restore workflow to 'ready' status (current: '{}')",
-                    refreshed.status
-                )));
-            }
-
-            Workflow::update_status(&deployment.db().pool, &workflow_id, WORKFLOW_STATUS_PAUSED)
-                .await?;
-        }
-    }
-
-    // Delegate to the runtime which performs paused -> ready CAS and agent creation
-    deployment
-        .orchestrator_runtime()
-        .resume_workflow(&workflow_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                workflow_id = %workflow_id,
-                error = ?e,
-                "Failed to resume workflow"
-            );
-            ApiError::Internal("Failed to resume workflow".to_string())
-        })?;
-
-    refresh_prompt_watcher_registrations(&deployment, &workflow_id).await;
-
-    tracing::info!(workflow_id = %workflow_id, "Workflow resumed successfully");
 
     Ok(ResponseJson(ApiResponse::success(())))
 }

--- a/crates/server/src/self_test/tests.rs
+++ b/crates/server/src/self_test/tests.rs
@@ -228,7 +228,6 @@ fn all_test_cases() -> Vec<TestCase> {
         test!("workflow_ops", "recover_workflows", test_recover_workflows),
         test!("workflow_ops", "start_workflow", test_start_workflow),
         test!("workflow_ops", "pause_workflow", test_pause_workflow),
-        test!("workflow_ops", "resume_workflow", test_resume_workflow),
         test!("workflow_ops", "stop_workflow", test_stop_workflow),
         test!("workflow_ops", "merge_workflow", test_merge_workflow),
         test!(
@@ -1407,18 +1406,6 @@ async fn test_pause_workflow(ctx: &mut TestContext) -> Result<(), String> {
         .await
         .map_err(|e| e.to_string())?;
     assert_not_500(resp, "pause_workflow").await?;
-    Ok(())
-}
-
-async fn test_resume_workflow(ctx: &mut TestContext) -> Result<(), String> {
-    let id = ctx.workflow_id.as_ref().ok_or("No workflow_id")?;
-    let resp = ctx
-        .client
-        .post(ctx.api(&format!("/workflows/{id}/resume")))
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-    assert_not_500(resp, "resume_workflow").await?;
     Ok(())
 }
 

--- a/crates/services/src/services/orchestrator/runtime.rs
+++ b/crates/services/src/services/orchestrator/runtime.rs
@@ -837,59 +837,6 @@ impl OrchestratorRuntime {
         Ok(())
     }
 
-    /// Resume a paused workflow (G05-002)
-    ///
-    /// Atomically transitions the workflow from `paused` to `ready` via CAS,
-    /// then delegates to `start_workflow` to create a fresh orchestrator agent.
-    ///
-    /// Returns `Err` if the workflow is not found, is not in `paused` state,
-    /// or if the CAS update races with a concurrent status change.
-    pub async fn resume_workflow(&self, workflow_id: &str) -> Result<()> {
-        let pool = &self.db.pool;
-
-        // Load workflow and verify it is paused
-        let workflow = db::models::Workflow::find_by_id(pool, workflow_id)
-            .await?
-            .ok_or_else(|| anyhow!("Workflow {workflow_id} not found"))?;
-
-        if workflow.status != WORKFLOW_STATUS_PAUSED {
-            return Err(anyhow!(
-                "Cannot resume workflow {workflow_id}: expected status '{}', got '{}'",
-                WORKFLOW_STATUS_PAUSED,
-                workflow.status
-            ));
-        }
-
-        // CAS: paused → ready
-        let now = chrono::Utc::now();
-        let result = sqlx::query(
-            r"
-            UPDATE workflow
-            SET status = 'ready', updated_at = ?
-            WHERE id = ? AND status = 'paused'
-            ",
-        )
-        .bind(now)
-        .bind(workflow_id)
-        .execute(pool)
-        .await
-        .map_err(|e| anyhow!("Failed to update workflow status during resume: {e}"))?;
-
-        if result.rows_affected() == 0 {
-            return Err(anyhow!(
-                "Cannot resume workflow {workflow_id}: status changed concurrently"
-            ));
-        }
-
-        info!(
-            workflow_id = %workflow_id,
-            "Workflow transitioned paused → ready for resume"
-        );
-
-        // Delegate to start_workflow which handles slot reservation and agent creation
-        self.start_workflow(workflow_id).await
-    }
-
     /// Check if a workflow is currently running
     pub async fn is_running(&self, workflow_id: &str) -> bool {
         let running = self.running_workflows.lock().await;


### PR DESCRIPTION
## What

Deletes the `POST /api/workflows/{workflow_id}/resume` endpoint and its supporting code.

Since #41 the frontend resumes paused workflows through `POST /start` — see the comment in `frontend/src/pages/Pipeline.tsx`. A grep over `frontend/src` (and the whole repo, all file types) confirms nothing referenced `/resume`; the only remaining mention is a historical debugging log under `docs/undeveloped/`, left as-is.

## Why

`/start` already documents itself as *"Start workflow (user confirmed) or resume from paused state"* and is a strict superset of what `/resume` did: it validates a wider status set, performs the same `paused → ready` CAS, self-heals terminals, branches on `orchestrator_enabled`, and calls `refresh_prompt_watcher_registrations` in its common tail so both execution modes are covered.

Meanwhile `/resume` carried two latent defects, reachable by anyone who hand-crafted a request:

1. **Spawned an orchestrator agent for DIY workflows.** It delegated unconditionally to `OrchestratorRuntime::resume_workflow` → `start_workflow` → `start_workflow_reserved`, which always constructs an `OrchestratorAgent` regardless of `workflow.orchestrator_enabled`. That both created an agent that should not exist and skipped the task/terminal activation `/start` performs for DIY mode.

2. **Force-launched every PTY after any restart.** Its `needs_reprepare` predicate treated any terminal whose status was not exactly `waiting` as broken. `reconcile_terminal_statuses` resets every terminal to `not_started` on startup, so `/resume` always took the re-prepare branch — duplicating work the orchestrator dispatch loop already does through the global cap-aware path. `/start` deliberately tolerates `not_started` for exactly this reason.

Fixing both in place would mean copying `/start`'s whole DIY activation branch into the resume handler — re-implementing `/start` for an endpoint no client calls. Deleting is the smaller change.

## Removed

- Route registration + `resume_workflow` handler (`crates/server/src/routes/workflows.rs`)
- `OrchestratorRuntime::resume_workflow` (`crates/services/src/services/orchestrator/runtime.rs`)
- `test_resume_workflow` self-test case + its registry entry (`crates/server/src/self_test/tests.rs`)
- `Workflow::set_created_from_paused` (`crates/db/src/models/workflow.rs`) — its only caller was the deleted re-prepare branch

Pure deletion: 214 lines, no behavioral change to any reachable path. The only prior coverage was the self-test `assert_not_500` smoke check for a route that no longer exists; `crates/server/tests/workflow_api_test.rs` had no `/resume` test.

## Follow-up (not in this PR)

The CORE-019 CAS hardening only ever existed on this dead path. The live `/start` re-prepare branch still does a **non-CAS** `update_status(..., "created")`, so the race CORE-019 described was never actually fixed where users hit it. Note a fix is not a straight restore of `set_created_from_paused`: that helper keyed on `status = 'paused'`, but `/start`'s re-prepare is reachable from both `ready` and `paused`, so it needs a broader CAS predicate.

## Verification

| Gate | Result |
|---|---|
| `cargo clippy --workspace --exclude solodawn-tray --all-targets --all-features -- -D warnings` | ✅ exit 0, zero warnings |
| `cargo nextest run --workspace --exclude solodawn-tray --lib` | ✅ 1140 passed, 1 skipped |
| `cargo run --bin generate_types -- --check` | ✅ exit 0 |
| `pnpm run check` / `pnpm run lint` / `pnpm test:run` | ✅ 0 / 0 / 76 test files passed |

Frontend Check is expected to show **skipped** in CI — the `dorny/paths-filter` step gates it on `frontend/**` / `shared/**`, and this diff is backend-only.
