### PR TITLE
fix(server): CAS-guard the start-phase re-prepare status write

### DIFF
--- a/crates/db/src/models/workflow.rs
+++ b/crates/db/src/models/workflow.rs
@@ -710,6 +710,31 @@ impl Workflow {
         Ok(())
     }
 
+    /// Atomically transition a relaunchable workflow to 'created' (CAS).
+    ///
+    /// CORE-019: Used by the start-flow re-prepare path, which is reachable from
+    /// both 'ready' and 'paused'. Returning `Ok(false)` (rather than an error)
+    /// signals that the workflow was in neither state when the UPDATE executed —
+    /// e.g. a concurrent stop/pause raced ahead of the caller's earlier status
+    /// read. The caller MUST treat `false` as a conflict and abort the re-prepare
+    /// instead of proceeding with a non-CAS write.
+    pub async fn set_created_from_relaunchable(pool: &SqlitePool, id: &str) -> sqlx::Result<bool> {
+        let now = Utc::now();
+        let result = sqlx::query(
+            r"
+            UPDATE workflow
+            SET status = 'created', updated_at = ?
+            WHERE id = ? AND status IN ('ready', 'paused')
+            ",
+        )
+        .bind(now)
+        .bind(id)
+        .execute(pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
     /// Set workflow to ready (only from 'starting' state).
     ///
     /// Uses CAS to ensure workflow is in 'starting' state before transitioning
@@ -1492,5 +1517,94 @@ mod encryption_tests {
                 assert!(!json.contains("sk-test"));
             },
         );
+    }
+}
+
+#[cfg(test)]
+mod status_cas_tests {
+    use super::*;
+
+    const WORKFLOW_ID: &str = "workflow-cas";
+
+    /// Minimal `workflow` table holding a single row in `status`.
+    async fn pool_with_workflow(status: &str) -> SqlitePool {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::query(
+            r"
+            CREATE TABLE workflow (
+                id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                updated_at TEXT
+            )
+            ",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query("INSERT INTO workflow (id, status) VALUES (?1, ?2)")
+            .bind(WORKFLOW_ID)
+            .bind(status)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        pool
+    }
+
+    async fn current_status(pool: &SqlitePool) -> String {
+        sqlx::query_scalar("SELECT status FROM workflow WHERE id = ?1")
+            .bind(WORKFLOW_ID)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn set_created_from_relaunchable_accepts_both_relaunchable_states() {
+        for source in ["ready", "paused"] {
+            let pool = pool_with_workflow(source).await;
+
+            assert!(
+                Workflow::set_created_from_relaunchable(&pool, WORKFLOW_ID)
+                    .await
+                    .unwrap(),
+                "CAS should succeed from '{source}'"
+            );
+            assert_eq!(current_status(&pool).await, "created");
+        }
+    }
+
+    #[tokio::test]
+    async fn set_created_from_relaunchable_rejects_concurrently_changed_status() {
+        // CORE-019: a stop/pause landing between the caller's status read and this
+        // write must be reported as a miss, never silently overwritten.
+        for source in ["cancelled", "running", "starting", "created", "completed", "failed"] {
+            let pool = pool_with_workflow(source).await;
+
+            assert!(
+                !Workflow::set_created_from_relaunchable(&pool, WORKFLOW_ID)
+                    .await
+                    .unwrap(),
+                "CAS should miss from '{source}'"
+            );
+            assert_eq!(
+                current_status(&pool).await,
+                source,
+                "a CAS miss must leave status '{source}' untouched"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn set_created_from_relaunchable_reports_miss_for_unknown_workflow() {
+        let pool = pool_with_workflow("ready").await;
+
+        assert!(
+            !Workflow::set_created_from_relaunchable(&pool, "no-such-workflow")
+                .await
+                .unwrap()
+        );
+        assert_eq!(current_status(&pool).await, "ready");
     }
 }

--- a/crates/server/src/routes/workflows.rs
+++ b/crates/server/src/routes/workflows.rs
@@ -37,8 +37,9 @@ use services::services::{
         constants::{
             TASK_STATUS_CANCELLED, TASK_STATUS_COMPLETED, TASK_STATUS_FAILED,
             TERMINAL_STATUS_CANCELLED, TERMINAL_STATUS_COMPLETED, TERMINAL_STATUS_FAILED,
-            TERMINAL_STATUS_QUALITY_PENDING, TERMINAL_STATUS_STARTING, TERMINAL_STATUS_WAITING,
-            TERMINAL_STATUS_WORKING, WORKFLOW_STATUS_PAUSED, WORKFLOW_STATUS_RUNNING,
+            TERMINAL_STATUS_NOT_STARTED, TERMINAL_STATUS_QUALITY_PENDING, TERMINAL_STATUS_STARTING,
+            TERMINAL_STATUS_WAITING, TERMINAL_STATUS_WORKING, WORKFLOW_STATUS_PAUSED,
+            WORKFLOW_STATUS_RUNNING,
             configured_max_concurrent_terminals,
         },
     },
@@ -1960,6 +1961,29 @@ async fn render_workflow_commands(
     Ok(rendered)
 }
 
+/// Whether a `ready`/`paused` workflow's terminals must be re-prepared before start.
+///
+/// A restarted backend reconciles every terminal to `not_started`; those are queued
+/// and launch normally under the global concurrency cap, so they must NOT force a
+/// re-prepare — treating them as broken force-launches every PTY and duplicates the
+/// work the cap-aware dispatch path already does. A `waiting` terminal is only
+/// launch-ready while it still holds a live PTY/session binding. Any other status
+/// means the terminal is not in a startable shape and the workflow needs re-preparing.
+fn workflow_terminals_need_reprepare(terminals: &[Terminal]) -> bool {
+    terminals
+        .iter()
+        .any(|terminal| match terminal.status.as_str() {
+            TERMINAL_STATUS_NOT_STARTED => false,
+            TERMINAL_STATUS_WAITING => terminal
+                .pty_session_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|session| !session.is_empty())
+                .is_none(),
+            _ => true,
+        })
+}
+
 /// POST /api/workflows/:workflow_id/start
 /// Start workflow (user confirmed) or resume from paused state
 async fn start_workflow(
@@ -2009,35 +2033,41 @@ async fn start_workflow(
 
     // Self-heal for restarted backend: a workflow may still be `ready` while terminals were
     // reconciled to `not_started` (missing active PTY/session). Re-prepare before starting.
-    // TODO(G16-008): Extract this re-prepare block into a dedicated `re_prepare_if_needed()`
-    // function to reduce start_workflow complexity and improve testability.
+    // TODO(G16-008): The readiness predicate is extracted and unit-tested as
+    // `workflow_terminals_need_reprepare`; the surrounding block still needs lifting into a
+    // dedicated `re_prepare_if_needed()` to reduce start_workflow complexity.
     if workflow.status == "ready" || workflow.status == WORKFLOW_STATUS_PAUSED {
         let terminals =
             db::models::Terminal::find_by_workflow(&deployment.db().pool, &workflow_id).await?;
 
-        let needs_reprepare = terminals
-            .iter()
-            .any(|terminal| match terminal.status.as_str() {
-                // Queued terminals are valid under the global concurrency cap.
-                "not_started" => false,
-                // Waiting terminals must have a live PTY/session binding.
-                "waiting" => terminal
-                    .pty_session_id
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|session| !session.is_empty())
-                    .is_none(),
-                _ => true,
-            });
-
-        if needs_reprepare {
+        if workflow_terminals_need_reprepare(&terminals) {
             tracing::warn!(
                 workflow_id = %workflow_id,
                 workflow_status = %workflow.status,
                 "Workflow terminals are not launch-ready; re-preparing before start"
             );
 
-            Workflow::update_status(&deployment.db().pool, &workflow_id, "created").await?;
+            // CORE-019: Use a CAS update (ready|paused -> created) so a concurrent
+            // stop/pause landing between the status read above and this write is
+            // detected here instead of being silently clobbered. If 0 rows were
+            // affected, the workflow is no longer relaunchable — return a Conflict
+            // error and do NOT call prepare_workflow, which would otherwise act on
+            // stale state.
+            let cas_succeeded =
+                Workflow::set_created_from_relaunchable(&deployment.db().pool, &workflow_id)
+                    .await
+                    .map_err(|e| {
+                        ApiError::Internal(format!(
+                            "Start-phase CAS status update failed for workflow {workflow_id}: {e}"
+                        ))
+                    })?;
+
+            if !cas_succeeded {
+                return Err(ApiError::Conflict(format!(
+                    "Workflow {workflow_id} is no longer 'ready' or 'paused' (likely modified by a \
+                     concurrent stop/pause); aborting start re-prepare"
+                )));
+            }
 
             // G03-002: Wrap re-prepare error with descriptive context
             let _ = prepare_workflow(
@@ -4399,6 +4429,80 @@ mod workflow_guard_tests {
             created_at: now,
             updated_at: now,
         }
+    }
+
+    fn build_waiting_terminal(pty_session_id: Option<&str>) -> Terminal {
+        let mut terminal = build_terminal_with_status("task-test", TERMINAL_STATUS_WAITING);
+        terminal.pty_session_id = pty_session_id.map(ToString::to_string);
+        terminal
+    }
+
+    #[test]
+    fn reprepare_guard_ignores_empty_terminal_set() {
+        assert!(!workflow_terminals_need_reprepare(&[]));
+    }
+
+    #[test]
+    fn reprepare_guard_tolerates_queued_not_started_terminals() {
+        let terminals = [
+            build_terminal_with_status("task-test", TERMINAL_STATUS_NOT_STARTED),
+            build_terminal_with_status("task-test", TERMINAL_STATUS_NOT_STARTED),
+        ];
+
+        assert!(
+            !workflow_terminals_need_reprepare(&terminals),
+            "queued not_started terminals launch under the concurrency cap and must not \
+             trigger re-prepare"
+        );
+    }
+
+    #[test]
+    fn reprepare_guard_requires_live_session_for_waiting_terminals() {
+        assert!(!workflow_terminals_need_reprepare(&[build_waiting_terminal(
+            Some("pty-42")
+        )]));
+
+        for missing in [None, Some(""), Some("   ")] {
+            assert!(
+                workflow_terminals_need_reprepare(&[build_waiting_terminal(missing)]),
+                "waiting terminal with pty_session_id {missing:?} should force re-prepare"
+            );
+        }
+    }
+
+    #[test]
+    fn reprepare_guard_flags_every_other_terminal_status() {
+        let broken_statuses = [
+            TERMINAL_STATUS_STARTING,
+            TERMINAL_STATUS_WORKING,
+            TERMINAL_STATUS_COMPLETED,
+            TERMINAL_STATUS_FAILED,
+            TERMINAL_STATUS_CANCELLED,
+            TERMINAL_STATUS_QUALITY_PENDING,
+            "review_passed",
+            "some_unknown_status",
+        ];
+
+        for status in broken_statuses {
+            assert!(
+                workflow_terminals_need_reprepare(&[build_terminal_with_status(
+                    "task-test",
+                    status
+                )]),
+                "terminal status '{status}' should force re-prepare"
+            );
+        }
+    }
+
+    #[test]
+    fn reprepare_guard_flags_mixed_set_containing_one_broken_terminal() {
+        let terminals = [
+            build_terminal_with_status("task-test", TERMINAL_STATUS_NOT_STARTED),
+            build_waiting_terminal(Some("pty-1")),
+            build_terminal_with_status("task-test", TERMINAL_STATUS_FAILED),
+        ];
+
+        assert!(workflow_terminals_need_reprepare(&terminals));
     }
 
     #[test]


### PR DESCRIPTION
`start_workflow`'s self-heal re-prepare block wrote the workflow back to
`created` unconditionally:

    Workflow::update_status(&deployment.db().pool, &workflow_id, "created").await?;

`workflow.status` is read at the top of the handler, so a `stop_workflow` or
`pause_workflow` landing between that read and this write is lost:

- a concurrent **pause** (`ready`/`running` -> `paused`) is overwritten by
  `created`, since `update_status` only guards the three terminal states;
- a concurrent **stop** (`-> cancelled`) is not overwritten — `update_status`
  no-ops on terminal states — but the handler ignores that and still calls
  `prepare_workflow`, re-launching a workflow the user just cancelled.

The `/resume` path had the identical hazard hardened under CORE-019 with
`Workflow::set_created_from_paused`, a CAS keyed on `status='paused'`. #43
removed `/resume` and that helper, leaving `/start` — now the only caller of
this block — unguarded and no CAS helper in the tree.

## Fix

Restoring `set_created_from_paused` would be wrong: this branch is reachable
from **both** `ready` and `paused` (`if workflow.status == "ready" ||
workflow.status == WORKFLOW_STATUS_PAUSED`), so a `status='paused'` predicate
would reject every legitimate `ready` re-prepare.

Adds `Workflow::set_created_from_relaunchable`, a CAS over the two relaunchable
states, and returns `ApiError::Conflict` (409) without calling
`prepare_workflow` when it reports a miss:

    UPDATE workflow SET status = 'created', updated_at = ?
    WHERE id = ? AND status IN ('ready', 'paused')

`updated_at` binds `Utc::now()` to match every other CAS in the `Workflow`
model. `Conflict` matches what `prepare_workflow` already returns for its own
lost-race guard, and `handleApiResponse` surfaces the message unchanged, so no
frontend work is needed.

## Re-prepare readiness predicate

The readiness closure was the last copy after #43 and had no coverage. Extracted
to `workflow_terminals_need_reprepare(&[Terminal]) -> bool` with behavior
unchanged, and covered in `workflow_guard_tests`:

- `not_started` terminals are queued under the global concurrency cap and must
  **not** trigger re-prepare (the trap #43 documented in the deleted `/resume`
  copy, which force-launched every PTY);
- `waiting` requires a non-empty trimmed `pty_session_id` (`None`, `""`, `"   "`
  all trigger);
- every other status triggers, including unknown ones;
- the empty set does not.

`Workflow::set_created_from_relaunchable` gets its own hit/miss coverage in
`crates/db`, following the existing `Terminal::update_status_cas` test pattern:
CAS succeeds from `ready` and `paused`, misses from `cancelled`/`running`/
`starting`/`created`/`completed`/`failed` and for an unknown id, and leaves the
row untouched on a miss.

## Verification

- `cargo clippy --workspace --exclude solodawn-tray --all-targets --all-features --profile ci -- -D warnings` — clean
- `cargo nextest run --workspace --exclude solodawn-tray --cargo-profile ci --lib` — 1148 passed, 1 skipped (1140 before this change; +8 new)
