### PR TITLE
ci: restore main quality and Docker checks

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -99,7 +99,7 @@ runs:
         mkdir -p "${HOME}/.cargo/bin"
         # Tarball contains `cargo-nextest` (cargo-nextest.exe on Windows),
         # extracted straight onto PATH so `cargo nextest` resolves it.
-        curl -LsSf --retry 5 --retry-connrefused "${URL}" | tar zxf - -C "${HOME}/.cargo/bin"
+        curl -LsSf --retry 5 --retry-connrefused --proto '=https' --proto-redir '=https' "${URL}" | tar zxf - -C "${HOME}/.cargo/bin"
         cargo-nextest --version
 
     - name: Cache Rust build outputs (registry, git, target)

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -84,10 +84,10 @@ jobs:
     # no incremental) so clippy and nextest can share the same build
     # artifacts instead of rebuilding twice.
     - name: Prime build artifacts (shared by clippy + nextest)
-      run: cargo build $CARGO_SELECT --profile ci --tests --quiet
+      run: cargo build $CARGO_SELECT --profile ci --tests --quiet --locked
 
     - name: Run cargo clippy
-      run: cargo clippy $CARGO_SELECT --all-targets --all-features --profile ci -- -D warnings
+      run: cargo clippy $CARGO_SELECT --all-targets --all-features --profile ci --locked -- -D warnings
 
     # Performance: removed `--test-threads=1`. The original single-threaded
     # setting was an extremely broad hammer that forced the entire test
@@ -106,10 +106,10 @@ jobs:
       # win). NOTE: nextest's `--profile` is its own run-config profile (from
       # .config/nextest.toml), NOT a Cargo profile — there is no `ci` nextest
       # profile, so `--profile ci` errored with "profile `ci` not found".
-      run: cargo nextest run $CARGO_SELECT --cargo-profile ci --lib
+      run: cargo nextest run $CARGO_SELECT --cargo-profile ci --lib --locked
 
     - name: Check generated types are up-to-date
-      run: cargo run --bin generate_types --profile ci -- --check
+      run: cargo run --locked --bin generate_types --profile ci -- --check
 
     - name: Show sccache statistics
       if: always()

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -55,8 +55,8 @@ jobs:
         push: false
         tags: solodawn:ci-test
         cache-from: type=gha,scope=docker-build
-        # Scoped cache with version tag; GHA cache has a 7-day inactivity TTL enforced by GitHub
-        cache-to: type=gha,mode=max,scope=docker-build
+        # Keep cache-export outages non-fatal; image build failures still fail this job.
+        cache-to: type=gha,mode=max,scope=docker-build,ignore-error=true
 
     - name: Report build duration
       if: always()


### PR DESCRIPTION
## Summary

- require Cargo.lock consistency in every Basic Checks Cargo invocation
- restrict cargo-nextest downloads and redirects to HTTPS
- keep GitHub Actions cache-export outages non-fatal while preserving Docker build failures

## Root cause

The post-merge main run failed SonarCloud on two workflow vulnerabilities and Docker Build after the image had built successfully but the GHA cache exporter returned not_found.

## Verification

- git diff --check
- YAML parsed successfully for all three changed files
- cargo metadata --locked --no-deps --format-version 1
- verified --locked support for build, clippy, nextest, and run