### PR TITLE
fix(workflow): 修复自定义工作流的密码误报、CLI/模型绑定与串行执行

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6550,6 +6550,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tokio-util",
+ "toml 0.8.2",
  "tonic",
  "tonic-build",
  "tracing",

--- a/crates/db/src/models/cli_type.rs
+++ b/crates/db/src/models/cli_type.rs
@@ -254,24 +254,35 @@ impl ModelConfig {
         cli_type_id: &str,
         display_name: &str,
         api_model_id: &str,
+        api_type: Option<&str>,
+        base_url: Option<&str>,
     ) -> sqlx::Result<Self> {
         let now = chrono::Utc::now();
         // Use the ID as the name for custom configs
         let name = id.to_string();
 
+        let api_type = api_type.map(str::trim).filter(|value| !value.is_empty());
+        let base_url = base_url.map(str::trim).filter(|value| !value.is_empty());
+
         // Insert or update model fields on conflict (ensures latest model ID is always stored)
         // Also update cli_type_id on conflict to fix mismatches from startup sync
         // (e.g., sync defaulted to "cli-codex" but wizard uses "cli-claude-code").
+        //
+        // `api_type`/`base_url` use COALESCE so a later write that omits them
+        // (an older client, or a caller that only knows the model id) cannot
+        // erase provider routing that was already recorded.
         let item = sqlx::query_as::<_, ModelConfig>(
             r"
             INSERT INTO model_config (
                 id, cli_type_id, name, display_name, api_model_id,
-                is_default, is_official, created_at, updated_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, 0, 0, ?6, ?7)
+                is_default, is_official, created_at, updated_at, api_type, base_url
+            ) VALUES (?1, ?2, ?3, ?4, ?5, 0, 0, ?6, ?7, ?8, ?9)
             ON CONFLICT(id) DO UPDATE SET
                 cli_type_id = excluded.cli_type_id,
                 display_name = excluded.display_name,
                 api_model_id = excluded.api_model_id,
+                api_type = COALESCE(excluded.api_type, model_config.api_type),
+                base_url = COALESCE(excluded.base_url, model_config.base_url),
                 updated_at = excluded.updated_at
             RETURNING id, cli_type_id, name, display_name, api_model_id,
                       is_default, is_official, created_at, updated_at,
@@ -285,6 +296,8 @@ impl ModelConfig {
         .bind(api_model_id)
         .bind(now)
         .bind(now)
+        .bind(api_type)
+        .bind(base_url)
         .fetch_one(pool)
         .await?;
         Ok(item.with_has_api_key())

--- a/crates/db/src/models/terminal.rs
+++ b/crates/db/src/models/terminal.rs
@@ -118,10 +118,12 @@ pub struct Terminal {
     /// Associated solodawn session ID
     pub vk_session_id: Option<Uuid>,
 
-    /// Auto-confirm mode: skip CLI permission prompts
-    /// When enabled, CLI will be launched with auto-confirm flags:
-    /// - Claude Code: --dangerously-skip-permissions
-    /// - Codex: --yolo
+    /// Auto-confirm mode: skip CLI permission prompts.
+    ///
+    /// How it is applied depends on the CLI:
+    /// - Claude Code: `--dangerously-skip-permissions` (plus `--bare`)
+    /// - Codex: `approval_policy = "never"` in the generated `config.toml`.
+    ///   Codex has no `--yolo` flag; approval is configuration-driven.
     pub auto_confirm: bool,
 
     /// Last Git commit hash

--- a/crates/db/src/models/workflow.rs
+++ b/crates/db/src/models/workflow.rs
@@ -367,6 +367,15 @@ pub struct InlineModelConfig {
     pub display_name: String,
     /// API model ID (e.g., "glm-5", "claude-sonnet-5")
     pub model_id: String,
+    /// API type chosen in the model dialog (`anthropic`, `openai-compatible`, ...).
+    ///
+    /// Persisted so the launcher knows which provider wire family a terminal's
+    /// model speaks without having to guess from the base URL.
+    #[serde(default)]
+    pub api_type: Option<String>,
+    /// Base URL chosen in the model dialog, persisted alongside `api_type`.
+    #[serde(default)]
+    pub base_url: Option<String>,
 }
 
 /// Default function for auto_confirm field - defaults to true for safety

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -271,6 +271,8 @@ async fn run_server() -> Result<(), SoloDawnError> {
                 cli_type_id,
                 &item.display_name,
                 &item.model_id,
+                Some(&item.api_type),
+                Some(&item.base_url),
             )
             .await
             {

--- a/crates/server/src/routes/config.rs
+++ b/crates/server/src/routes/config.rs
@@ -273,6 +273,8 @@ async fn sync_model_library_to_db(
             cli_type_id,
             &item.display_name,
             &item.model_id,
+            Some(&item.api_type),
+            Some(&item.base_url),
         )
         .await
         {

--- a/crates/server/src/routes/models.rs
+++ b/crates/server/src/routes/models.rs
@@ -51,11 +51,32 @@ struct VerifyModelRequest {
     api_key: String,
     #[serde(rename = "modelId")]
     model_id: String,
+    /// CLI this model is bound to, when the caller knows it.
+    ///
+    /// Verification must exercise the API surface the CLI will really call.
+    /// Codex speaks the OpenAI **Responses** API, so a model that only answers
+    /// on `/chat/completions` used to verify green and then be completely
+    /// unusable inside a Codex terminal.
+    #[serde(rename = "cliTypeId", default)]
+    cli_type_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
 struct VerifyModelResponse {
     verified: bool,
+    /// Why verification failed, when it did. `None` on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+/// Whether a CLI type id refers to Codex.
+///
+/// Accepts both the DB id (`cli-codex`) and the bare CLI name (`codex`).
+fn is_codex_cli(cli_type_id: Option<&str>) -> bool {
+    cli_type_id
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|value| value == "codex" || value == "cli-codex")
 }
 
 /// GET /api/models/list
@@ -90,18 +111,26 @@ async fn verify_model(
     Json(payload): Json<VerifyModelRequest>,
 ) -> Result<ResponseJson<VerifyModelResponse>, ApiError> {
     let client = http_client()?;
+    let base_url = trim_trailing_slash(&payload.base_url);
 
-    let verified = match payload.api_type.as_str() {
+    // Codex only speaks the Responses API. Verifying it through Chat
+    // Completions would report a green connection for an endpoint the Codex
+    // terminal cannot use at all.
+    if is_codex_cli(payload.cli_type_id.as_deref()) {
+        let outcome =
+            verify_openai_responses_model(&client, &base_url, &payload.api_key, &payload.model_id)
+                .await;
+        return Ok(ResponseJson(verify_outcome_to_response(outcome)));
+    }
+
+    let outcome = match payload.api_type.as_str() {
         "openai" | "openai-compatible" => {
-            let base_url = trim_trailing_slash(&payload.base_url);
             verify_openai_model(&client, &base_url, &payload.api_key, &payload.model_id).await
         }
         "anthropic" | "anthropic-compatible" => {
-            let base_url = trim_trailing_slash(&payload.base_url);
             verify_anthropic_model(&client, &base_url, &payload.api_key, &payload.model_id).await
         }
         "google" => {
-            let base_url = trim_trailing_slash(&payload.base_url);
             verify_google_model(&client, &base_url, &payload.api_key, &payload.model_id).await
         }
         other => {
@@ -111,9 +140,27 @@ async fn verify_model(
         }
     };
 
-    Ok(ResponseJson(VerifyModelResponse {
-        verified: verified.unwrap_or(false),
-    }))
+    Ok(ResponseJson(verify_outcome_to_response(outcome)))
+}
+
+/// Result of one verification attempt: verified, or a user-facing reason.
+type VerifyOutcome = Result<bool, String>;
+
+fn verify_outcome_to_response(outcome: VerifyOutcome) -> VerifyModelResponse {
+    match outcome {
+        Ok(true) => VerifyModelResponse {
+            verified: true,
+            detail: None,
+        },
+        Ok(false) => VerifyModelResponse {
+            verified: false,
+            detail: None,
+        },
+        Err(detail) => VerifyModelResponse {
+            verified: false,
+            detail: Some(detail),
+        },
+    }
 }
 
 fn api_key_from_headers(headers: &HeaderMap) -> Result<String, ApiError> {
@@ -163,16 +210,41 @@ fn join_url(base: &str, path: &str) -> String {
     )
 }
 
-/// Build an Anthropic-compatible endpoint URL, auto-inserting `/v1` when the
-/// caller-supplied base URL does not already end in `/v1`.
-fn anthropic_endpoint(base: &str, path: &str) -> String {
+/// Candidate URLs to try for `path` under a user-supplied base URL.
+///
+/// Providers document their base URL inconsistently: some publish
+/// `https://host` and expect the client to append `/v1`, others publish
+/// `https://host/v1` already. Guessing one convention makes the other fail with
+/// a bare 404 — which is what "the fetch-models button returns nothing" looked
+/// like for OpenAI-compatible relays, where only `{base}/models` was ever tried.
+///
+/// Both spellings are attempted, most-likely first, with duplicates removed so a
+/// base that already ends in `/v1` is never turned into `/v1/v1`.
+fn endpoint_candidates(base: &str, path: &str) -> Vec<String> {
     let trimmed = base.trim_end_matches('/');
     let leaf = path.trim_start_matches('/');
-    if trimmed.ends_with("/v1") {
-        format!("{trimmed}/{leaf}")
+
+    let mut candidates = Vec::with_capacity(2);
+    let mut push = |url: String| {
+        if !candidates.contains(&url) {
+            candidates.push(url);
+        }
+    };
+
+    if trimmed.ends_with("/v1") || trimmed.contains("/v1/") {
+        // Base already carries the version segment — use it verbatim first, and
+        // fall back to the base with that segment removed rather than appending
+        // a second one (which would produce `/v1/v1/...`).
+        push(format!("{trimmed}/{leaf}"));
+        if let Some(without_version) = trimmed.strip_suffix("/v1") {
+            push(format!("{without_version}/{leaf}"));
+        }
     } else {
-        format!("{trimmed}/v1/{leaf}")
+        push(format!("{trimmed}/v1/{leaf}"));
+        push(format!("{trimmed}/{leaf}"));
     }
+
+    candidates
 }
 
 // ============================================================================
@@ -184,30 +256,76 @@ async fn list_openai_models(
     base_url: &str,
     api_key: &str,
 ) -> Result<Vec<String>, ApiError> {
-    let url = join_url(base_url, "models");
-    tracing::debug!("Fetching models from: {}", url);
+    let mut attempts = Vec::new();
 
-    let response = client
-        .get(&url)
-        .header("Authorization", format!("Bearer {api_key}"))
-        .send()
-        .await
-        .map_err(|e| ApiError::Internal(format!("Failed to fetch models: {e}")))?;
+    for url in endpoint_candidates(base_url, "models") {
+        tracing::debug!("Fetching models from: {}", url);
+
+        let response = client
+            .get(&url)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .send()
+            .await;
+
+        match model_list_attempt(response, &url).await {
+            Ok(models) => return Ok(models),
+            Err(detail) => attempts.push(detail),
+        }
+    }
+
+    Err(model_list_error(&attempts))
+}
+
+/// Evaluate one model-list HTTP attempt.
+///
+/// `Ok` carries the parsed model ids; `Err` carries a human-readable reason
+/// suitable for showing the user, so a failure explains itself instead of
+/// collapsing into an empty dropdown.
+async fn model_list_attempt(
+    response: Result<reqwest::Response, reqwest::Error>,
+    url: &str,
+) -> Result<Vec<String>, String> {
+    let response = match response {
+        Ok(response) => response,
+        Err(e) => return Err(format!("{url} — request failed: {e}")),
+    };
 
     let status = response.status();
     let body = response.text().await.unwrap_or_default();
 
     if !status.is_success() {
-        tracing::warn!("Model list request failed: {} - {}", status, body);
-        return Err(ApiError::BadRequest(format!(
-            "Model list request failed: {status}"
-        )));
+        tracing::warn!("Model list request failed: {} {} - {}", url, status, body);
+        return Err(format!("{url} — HTTP {status}"));
     }
 
-    let json: Value = serde_json::from_str(&body)
-        .map_err(|e| ApiError::Internal(format!("Invalid model list response: {e}")))?;
+    let json: Value = match serde_json::from_str(&body) {
+        Ok(json) => json,
+        Err(e) => {
+            tracing::warn!("Model list response was not JSON: {} - {}", url, e);
+            return Err(format!("{url} — response was not JSON ({e})"));
+        }
+    };
 
-    Ok(extract_model_ids(&json))
+    let models = extract_model_ids(&json);
+    if models.is_empty() {
+        // A 200 with no recognisable model array means we hit something that is
+        // not the models endpoint (an SPA index page, a gateway landing route).
+        return Err(format!("{url} — response contained no model list"));
+    }
+
+    Ok(models)
+}
+
+/// Collapse every failed endpoint attempt into one actionable error.
+fn model_list_error(attempts: &[String]) -> ApiError {
+    if attempts.is_empty() {
+        return ApiError::BadRequest("Model list request failed".to_string());
+    }
+    ApiError::BadRequest(format!(
+        "Could not fetch the model list. Tried: {}. Check the base URL and API key, \
+         or type the model ID manually.",
+        attempts.join("; ")
+    ))
 }
 
 async fn verify_openai_model(
@@ -215,10 +333,7 @@ async fn verify_openai_model(
     base_url: &str,
     api_key: &str,
     model_id: &str,
-) -> Result<bool, ApiError> {
-    let url = join_url(base_url, "chat/completions");
-    tracing::debug!("Verifying model {} at: {}", model_id, url);
-
+) -> VerifyOutcome {
     let payload = serde_json::json!({
         "model": model_id,
         "messages": [{"role": "user", "content": "ping"}],
@@ -226,35 +341,109 @@ async fn verify_openai_model(
         "temperature": 0.0
     });
 
-    let response = client
-        .post(&url)
-        .header("Authorization", format!("Bearer {api_key}"))
-        .header("Content-Type", "application/json")
-        .json(&payload)
-        .send()
-        .await
-        .map_err(|e| {
-            tracing::warn!("Failed to verify model: {}", e);
-            ApiError::Internal(format!("Failed to verify model: {e}"))
-        })?;
-
-    let status = response.status();
-    if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
-        tracing::warn!("Model verification failed: {} - {}", status, body);
-        return Ok(false);
-    }
-
-    if !verify_response_body_ok(
-        &response.text().await.unwrap_or_default(),
+    verify_openai_style(
+        client,
+        base_url,
+        api_key,
+        model_id,
+        "chat/completions",
+        &payload,
         &["choices", "content"],
         "OpenAI",
-    ) {
-        return Ok(false);
+    )
+    .await
+}
+
+/// Verify against the OpenAI **Responses** API — the only wire protocol Codex
+/// supports (`wire_api = "chat"` was removed from Codex; see
+/// `create_codex_config`). An endpoint that answers Chat Completions but not
+/// Responses cannot drive a Codex terminal, and must not verify green.
+async fn verify_openai_responses_model(
+    client: &Client,
+    base_url: &str,
+    api_key: &str,
+    model_id: &str,
+) -> VerifyOutcome {
+    let payload = serde_json::json!({
+        "model": model_id,
+        "input": "ping",
+        "max_output_tokens": 16,
+        "stream": false
+    });
+
+    verify_openai_style(
+        client,
+        base_url,
+        api_key,
+        model_id,
+        "responses",
+        &payload,
+        &["output", "output_text", "content", "id"],
+        "OpenAI Responses",
+    )
+    .await
+    .map_err(|detail| {
+        format!(
+            "{detail}\nCodex requires the OpenAI Responses API. This endpoint did not answer it, \
+             so the model will not work in a Codex terminal even if Chat Completions succeeds."
+        )
+    })
+}
+
+/// Shared POST-and-validate loop for the OpenAI-shaped endpoints, trying both
+/// `{base}/{path}` and `{base}/v1/{path}`.
+#[allow(clippy::too_many_arguments)]
+async fn verify_openai_style(
+    client: &Client,
+    base_url: &str,
+    api_key: &str,
+    model_id: &str,
+    path: &str,
+    payload: &Value,
+    expected_keys: &[&str],
+    label: &str,
+) -> VerifyOutcome {
+    let mut attempts = Vec::new();
+
+    for url in endpoint_candidates(base_url, path) {
+        tracing::debug!("Verifying model {} at: {}", model_id, url);
+
+        let response = client
+            .post(&url)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .header("Content-Type", "application/json")
+            .json(payload)
+            .send()
+            .await;
+
+        let response = match response {
+            Ok(response) => response,
+            Err(e) => {
+                tracing::warn!("Failed to verify model at {}: {}", url, e);
+                attempts.push(format!("{url} — request failed: {e}"));
+                continue;
+            }
+        };
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+
+        if !status.is_success() {
+            tracing::warn!("{label} verification failed: {} {} - {}", url, status, body);
+            attempts.push(format!("{url} — HTTP {status}"));
+            continue;
+        }
+
+        if !verify_response_body_ok(&body, expected_keys, label) {
+            attempts.push(format!("{url} — HTTP 200 but the body was not a {label} reply"));
+            continue;
+        }
+
+        tracing::info!("Model {} verified successfully at {}", model_id, url);
+        return Ok(true);
     }
 
-    tracing::info!("Model {} verified successfully", model_id);
-    Ok(true)
+    Err(format!("Tried: {}", attempts.join("; ")))
 }
 
 // ============================================================================
@@ -266,31 +455,29 @@ async fn list_anthropic_models(
     base_url: &str,
     api_key: &str,
 ) -> Result<Vec<String>, ApiError> {
-    let url = anthropic_endpoint(base_url, "models");
-    tracing::debug!("Fetching Anthropic models from: {}", url);
+    let mut attempts = Vec::new();
 
-    let response = client
-        .get(&url)
-        .header("x-api-key", api_key)
-        .header("anthropic-version", ANTHROPIC_VERSION)
-        .send()
-        .await
-        .map_err(|e| ApiError::Internal(format!("Failed to fetch models: {e}")))?;
+    for url in endpoint_candidates(base_url, "models") {
+        tracing::debug!("Fetching Anthropic models from: {}", url);
 
-    let status = response.status();
-    let body = response.text().await.unwrap_or_default();
+        // Anthropic-compatible relays are frequently multi-protocol gateways
+        // that authenticate with either header, so send both rather than
+        // failing on a gateway that only understands `Authorization`.
+        let response = client
+            .get(&url)
+            .header("x-api-key", api_key)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .send()
+            .await;
 
-    if !status.is_success() {
-        tracing::warn!("Anthropic model list request failed: {} - {}", status, body);
-        return Err(ApiError::BadRequest(format!(
-            "Model list request failed: {status}"
-        )));
+        match model_list_attempt(response, &url).await {
+            Ok(models) => return Ok(models),
+            Err(detail) => attempts.push(detail),
+        }
     }
 
-    let json: Value = serde_json::from_str(&body)
-        .map_err(|e| ApiError::Internal(format!("Invalid model list response: {e}")))?;
-
-    Ok(extract_model_ids(&json))
+    Err(model_list_error(&attempts))
 }
 
 async fn verify_anthropic_model(
@@ -298,43 +485,62 @@ async fn verify_anthropic_model(
     base_url: &str,
     api_key: &str,
     model_id: &str,
-) -> Result<bool, ApiError> {
-    let url = anthropic_endpoint(base_url, "messages");
-    tracing::debug!("Verifying Anthropic model {} at: {}", model_id, url);
-
+) -> VerifyOutcome {
     let payload = serde_json::json!({
         "model": model_id,
         "messages": [{"role": "user", "content": "ping"}],
         "max_tokens": 32
     });
 
-    let response = client
-        .post(&url)
-        .header("x-api-key", api_key)
-        .header("anthropic-version", ANTHROPIC_VERSION)
-        .header("Content-Type", "application/json")
-        .json(&payload)
-        .send()
-        .await
-        .map_err(|e| ApiError::Internal(format!("Failed to verify model: {e}")))?;
+    let mut attempts = Vec::new();
 
-    let status = response.status();
-    if !status.is_success() {
+    for url in endpoint_candidates(base_url, "messages") {
+        tracing::debug!("Verifying Anthropic model {} at: {}", model_id, url);
+
+        let response = client
+            .post(&url)
+            .header("x-api-key", api_key)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("Content-Type", "application/json")
+            .json(&payload)
+            .send()
+            .await;
+
+        let response = match response {
+            Ok(response) => response,
+            Err(e) => {
+                attempts.push(format!("{url} — request failed: {e}"));
+                continue;
+            }
+        };
+
+        let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        tracing::warn!("Anthropic model verification failed: {} - {}", status, body);
-        return Ok(false);
+
+        if !status.is_success() {
+            tracing::warn!(
+                "Anthropic model verification failed: {} {} - {}",
+                url,
+                status,
+                body
+            );
+            attempts.push(format!("{url} — HTTP {status}"));
+            continue;
+        }
+
+        if !verify_response_body_ok(&body, &["content", "id"], "Anthropic") {
+            attempts.push(format!(
+                "{url} — HTTP 200 but the body was not an Anthropic reply"
+            ));
+            continue;
+        }
+
+        tracing::info!("Anthropic model {} verified successfully", model_id);
+        return Ok(true);
     }
 
-    if !verify_response_body_ok(
-        &response.text().await.unwrap_or_default(),
-        &["content", "id"],
-        "Anthropic",
-    ) {
-        return Ok(false);
-    }
-
-    tracing::info!("Anthropic model {} verified successfully", model_id);
-    Ok(true)
+    Err(format!("Tried: {}", attempts.join("; ")))
 }
 
 // ============================================================================
@@ -382,10 +588,17 @@ async fn verify_google_model(
     base_url: &str,
     api_key: &str,
     model_id: &str,
-) -> Result<bool, ApiError> {
-    let models = list_google_models(client, base_url, api_key).await?;
+) -> VerifyOutcome {
+    let models = list_google_models(client, base_url, api_key)
+        .await
+        .map_err(|e| format!("Could not list Google models: {e}"))?;
     let target = model_id.trim();
-    Ok(models.iter().any(|model| model == target))
+    if models.iter().any(|model| model == target) {
+        return Ok(true);
+    }
+    Err(format!(
+        "Model '{target}' is not in the endpoint's model list"
+    ))
 }
 
 // ============================================================================
@@ -465,4 +678,101 @@ fn extract_google_model_ids(json: &Value) -> Vec<String> {
     }
 
     models
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_candidates_tries_versioned_path_first_for_bare_base() {
+        // Providers commonly document `https://host` as the base URL and expect
+        // the client to append `/v1`. Only trying `{base}/models` produced a 404
+        // and an empty model dropdown.
+        assert_eq!(
+            endpoint_candidates("https://api.example.com", "models"),
+            vec![
+                "https://api.example.com/v1/models".to_string(),
+                "https://api.example.com/models".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn endpoint_candidates_never_doubles_an_existing_version_segment() {
+        let candidates = endpoint_candidates("https://api.example.com/v1", "models");
+        assert_eq!(candidates[0], "https://api.example.com/v1/models");
+        assert!(
+            !candidates.iter().any(|url| url.contains("/v1/v1/")),
+            "a base URL that already ends in /v1 must not become /v1/v1: {candidates:?}"
+        );
+    }
+
+    #[test]
+    fn endpoint_candidates_trims_trailing_slashes() {
+        assert_eq!(
+            endpoint_candidates("https://api.example.com/", "models")[0],
+            "https://api.example.com/v1/models"
+        );
+    }
+
+    #[test]
+    fn endpoint_candidates_respects_a_mid_path_version_segment() {
+        let candidates = endpoint_candidates("https://gateway.example.com/v1/openai", "models");
+        assert_eq!(candidates[0], "https://gateway.example.com/v1/openai/models");
+    }
+
+    #[test]
+    fn endpoint_candidates_deduplicates() {
+        // A base whose only difference between the two spellings is ordering
+        // must not produce the same URL twice.
+        let candidates = endpoint_candidates("https://api.example.com/v1", "models");
+        let mut sorted = candidates.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), candidates.len());
+    }
+
+    #[test]
+    fn codex_cli_is_recognised_by_id_and_by_name() {
+        assert!(is_codex_cli(Some("cli-codex")));
+        assert!(is_codex_cli(Some("codex")));
+        assert!(is_codex_cli(Some("  Codex  ")));
+        assert!(!is_codex_cli(Some("cli-claude-code")));
+        assert!(!is_codex_cli(None));
+    }
+
+    #[test]
+    fn model_list_error_names_every_attempted_endpoint() {
+        let error = model_list_error(&[
+            "https://a/v1/models — HTTP 404 Not Found".to_string(),
+            "https://a/models — HTTP 404 Not Found".to_string(),
+        ]);
+        let message = format!("{error:?}");
+        assert!(message.contains("https://a/v1/models"), "{message}");
+        assert!(message.contains("https://a/models"), "{message}");
+    }
+
+    #[test]
+    fn verify_outcome_carries_failure_detail_to_the_client() {
+        let response = verify_outcome_to_response(Err("Tried: https://a/v1/responses — HTTP 404".to_string()));
+        assert!(!response.verified);
+        assert!(
+            response.detail.is_some_and(|d| d.contains("responses")),
+            "a failed verification must explain which endpoint was tried"
+        );
+
+        let ok = verify_outcome_to_response(Ok(true));
+        assert!(ok.verified);
+        assert!(ok.detail.is_none());
+    }
+
+    #[test]
+    fn extract_model_ids_supports_both_documented_shapes() {
+        let openai = serde_json::json!({"data": [{"id": "gpt-x"}, {"id": "gpt-y"}]});
+        assert_eq!(extract_model_ids(&openai), vec!["gpt-x", "gpt-y"]);
+
+        let alternative = serde_json::json!({"models": [{"id": "m-1"}]});
+        assert_eq!(extract_model_ids(&alternative), vec!["m-1"]);
+    }
 }

--- a/crates/server/src/routes/workflows.rs
+++ b/crates/server/src/routes/workflows.rs
@@ -37,9 +37,10 @@ use services::services::{
         constants::{
             TASK_STATUS_CANCELLED, TASK_STATUS_COMPLETED, TASK_STATUS_FAILED,
             TERMINAL_STATUS_CANCELLED, TERMINAL_STATUS_COMPLETED, TERMINAL_STATUS_FAILED,
-            TERMINAL_STATUS_NOT_STARTED, TERMINAL_STATUS_QUALITY_PENDING, TERMINAL_STATUS_STARTING,
-            TERMINAL_STATUS_WAITING, TERMINAL_STATUS_WORKING, WORKFLOW_STATUS_PAUSED,
-            WORKFLOW_STATUS_RUNNING,
+            TERMINAL_STATUS_NOT_STARTED, TERMINAL_STATUS_QUALITY_PENDING,
+            TERMINAL_STATUS_REVIEW_PASSED, TERMINAL_STATUS_REVIEW_REJECTED,
+            TERMINAL_STATUS_STARTING, TERMINAL_STATUS_WAITING, TERMINAL_STATUS_WORKING,
+            WORKFLOW_STATUS_PAUSED, WORKFLOW_STATUS_RUNNING,
             configured_max_concurrent_terminals,
         },
     },
@@ -861,24 +862,29 @@ async fn validate_cli_and_model_configs(
             .await
             .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?;
 
-        let model_config = if let Some(mc) = model_config {
-            mc
-        } else {
-            // Model config not found - try to create from inline data
-            let inline = inline.ok_or_else(|| ApiError::BadRequest(format!(
-                "Model config not found: {model_config_id}. Provide inline modelConfig to auto-create."
-            )))?;
-
-            // Create custom model config from inline data
-            ModelConfig::create_custom(
+        // When the wizard supplies inline data, always upsert: an existing row
+        // created before provider routing was recorded would otherwise keep a
+        // NULL `api_type`, and the launcher would have to guess which provider
+        // wire family the terminal's model speaks. `create_custom` COALESCEs, so
+        // a request that omits those fields never erases them.
+        let model_config = match (model_config, inline) {
+            (_, Some(inline)) => ModelConfig::create_custom(
                 pool,
                 &model_config_id,
                 &cli_type_id,
                 &inline.display_name,
                 &inline.model_id,
+                inline.api_type.as_deref(),
+                inline.base_url.as_deref(),
             )
             .await
-            .map_err(|e| ApiError::Internal(format!("Failed to create model config: {e}")))?
+            .map_err(|e| ApiError::Internal(format!("Failed to create model config: {e}")))?,
+            (Some(mc), None) => mc,
+            (None, None) => {
+                return Err(ApiError::BadRequest(format!(
+                    "Model config not found: {model_config_id}. Provide inline modelConfig to auto-create."
+                )));
+            }
         };
 
         // Validate model config belongs to the CLI type
@@ -1984,6 +1990,84 @@ fn workflow_terminals_need_reprepare(terminals: &[Terminal]) -> bool {
         })
 }
 
+/// Terminal statuses that mean a DIY stage has finished and the next stage in
+/// the same task may start.
+const DIY_TERMINAL_FINISHED_STATUSES: [&str; 5] = [
+    TERMINAL_STATUS_COMPLETED,
+    TERMINAL_STATUS_FAILED,
+    TERMINAL_STATUS_CANCELLED,
+    TERMINAL_STATUS_REVIEW_PASSED,
+    TERMINAL_STATUS_REVIEW_REJECTED,
+];
+
+/// Whether a terminal status means the stage is done (successfully or not).
+fn is_diy_terminal_finished(status: &str) -> bool {
+    DIY_TERMINAL_FINISHED_STATUSES.contains(&status)
+}
+
+/// Poll interval while waiting for a DIY stage to finish.
+const DIY_STAGE_POLL_INTERVAL_SECS: u64 = 5;
+
+/// Upper bound on how long one DIY stage may block the next one.
+///
+/// A stage that never reports completion must not wedge the rest of the
+/// pipeline forever; after this budget the next stage starts anyway and the
+/// stall is logged. The DIY quiet-window monitor normally settles a terminal
+/// long before this.
+const DIY_STAGE_MAX_WAIT_SECS: u64 = 6 * 60 * 60;
+
+/// Block until `terminal_id` reaches a finished status, the terminal
+/// disappears, or the wait budget is exhausted.
+///
+/// Used to serialise a task's terminals: stage N+1 is only instructed once
+/// stage N has stopped working, so a configured pipeline
+/// (frontend -> backend -> audit) actually runs in that order.
+async fn wait_for_terminal_to_finish(pool: &sqlx::SqlitePool, terminal_id: &str) {
+    let deadline =
+        tokio::time::Instant::now() + std::time::Duration::from_secs(DIY_STAGE_MAX_WAIT_SECS);
+
+    loop {
+        match Terminal::find_by_id(pool, terminal_id).await {
+            Ok(Some(terminal)) => {
+                if is_diy_terminal_finished(&terminal.status) {
+                    tracing::info!(
+                        terminal_id = %terminal_id,
+                        status = %terminal.status,
+                        "DIY: stage finished; releasing the next stage in the task"
+                    );
+                    return;
+                }
+            }
+            Ok(None) => {
+                tracing::warn!(
+                    terminal_id = %terminal_id,
+                    "DIY: stage terminal no longer exists; releasing the next stage"
+                );
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    terminal_id = %terminal_id,
+                    error = %e,
+                    "DIY: failed to read stage status; releasing the next stage"
+                );
+                return;
+            }
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            tracing::warn!(
+                terminal_id = %terminal_id,
+                max_wait_secs = DIY_STAGE_MAX_WAIT_SECS,
+                "DIY: stage did not finish within the wait budget; starting the next stage anyway"
+            );
+            return;
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(DIY_STAGE_POLL_INTERVAL_SECS)).await;
+    }
+}
+
 /// POST /api/workflows/:workflow_id/start
 /// Start workflow (user confirmed) or resume from paused state
 async fn start_workflow(
@@ -2189,6 +2273,15 @@ async fn start_workflow(
         // auto-confirm can handle any permission prompts that appear immediately.
         refresh_prompt_watcher_registrations(&deployment, &workflow_id).await;
 
+        // Terminals that have actually been handed their instruction.
+        //
+        // Stages later in a task's pipeline are launched up-front but stay idle
+        // until their turn, so they look "quiet" from the moment they start. The
+        // quiet-window monitor below must not mistake that for completed work —
+        // it only judges terminals present in this set.
+        let dispatched_terminals: Arc<tokio::sync::RwLock<std::collections::HashSet<String>>> =
+            Arc::new(tokio::sync::RwLock::new(std::collections::HashSet::new()));
+
         // Auto-dispatch task descriptions as initial instructions to each terminal.
         // This makes DIY mode fully automated — terminals receive their instructions
         // without manual user intervention via WebSocket.
@@ -2197,6 +2290,7 @@ async fn start_workflow(
         {
             let dispatch_bus = deployment.message_bus().clone();
             let dispatch_db = deployment.db().pool.clone();
+            let dispatched_terminals = Arc::clone(&dispatched_terminals);
             let dispatch_tasks: Vec<_> = tasks
                 .iter()
                 .map(|t| (t.id.clone(), t.name.clone(), t.description.clone()))
@@ -2231,12 +2325,59 @@ async fn start_workflow(
                             continue;
                         }
                     };
-                    for terminal in &task_terminals {
+                    // A task's terminals are an ordered pipeline (`order_index`
+                    // ascending — e.g. frontend -> backend -> audit), not a fan-out
+                    // group. Each stage must observe the previous stage's work, so
+                    // hold the instruction back until the preceding terminal has
+                    // reached a terminal state. Previously every terminal in the
+                    // task was fed ~2s apart regardless, which made a configured
+                    // serial pipeline behave as if it ran in parallel.
+                    let mut previous_terminal_id: Option<String> = None;
+                    for snapshot in &task_terminals {
+                        if let Some(previous_terminal_id) = previous_terminal_id.take() {
+                            wait_for_terminal_to_finish(&dispatch_db, &previous_terminal_id).await;
+                        }
+
+                        // Re-read the row: waiting for the previous stage can take
+                        // hours, and a terminal relaunched in the meantime has a
+                        // different PTY session. Dispatching to the stale session id
+                        // from the snapshot taken before the wait would send the
+                        // instruction into a dead PTY.
+                        let terminal = match Terminal::find_by_id(&dispatch_db, &snapshot.id).await {
+                            Ok(Some(fresh)) => fresh,
+                            Ok(None) => {
+                                tracing::warn!(
+                                    terminal_id = %snapshot.id,
+                                    "DIY: terminal disappeared before its turn; skipping dispatch"
+                                );
+                                continue;
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    terminal_id = %snapshot.id,
+                                    error = %e,
+                                    "DIY: failed to refresh terminal before dispatch; skipping"
+                                );
+                                continue;
+                            }
+                        };
+                        let terminal = &terminal;
+
                         if let Some(ref pty_session_id) = terminal.pty_session_id {
+                            // Only a stage that was actually instructed gates the
+                            // next one; a terminal we skipped would never reach a
+                            // finished status and would stall the whole pipeline.
+                            previous_terminal_id = Some(terminal.id.clone());
                             let instruction = task_description.as_deref().unwrap_or(task_name);
                             if !instruction.is_empty() {
                                 // Small delay to ensure Claude Code has initialized
                                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                                // Arm the quiet-window monitor only now: before
+                                // this point the terminal is idle by design.
+                                dispatched_terminals
+                                    .write()
+                                    .await
+                                    .insert(terminal.id.clone());
                                 dispatch_bus
                                     .publish_terminal_input(
                                         &terminal.id,
@@ -2331,6 +2472,7 @@ async fn start_workflow(
         // completed after 60s of silence, then completes tasks/workflow.
         let diy_db = deployment.db().pool.clone();
         let diy_wf_id = workflow_id.clone();
+        let diy_dispatched_terminals = Arc::clone(&dispatched_terminals);
         let diy_process_manager = deployment.process_manager().clone();
         let diy_message_bus = deployment.message_bus().clone();
         tokio::spawn(async move {
@@ -2394,6 +2536,13 @@ async fn start_workflow(
 
                     for terminal in &terminals {
                         if terminal.status != "working" {
+                            continue;
+                        }
+                        // A stage that has not been instructed yet is idle by
+                        // design (it is waiting its turn in the task's serial
+                        // pipeline). Judging it by silence would mark every
+                        // later stage completed before it ever ran.
+                        if !diy_dispatched_terminals.read().await.contains(&terminal.id) {
                             continue;
                         }
                         // Check if terminal has been quiet
@@ -4285,6 +4434,62 @@ async fn merge_workflow(
 // ============================================================================
 // Contract Tests
 // ============================================================================
+
+#[cfg(test)]
+mod diy_stage_gate_tests {
+    use super::*;
+
+    /// A task's terminals form an ordered pipeline (frontend -> backend ->
+    /// audit). Stage N+1 is released only once stage N reaches one of these
+    /// statuses; previously every stage was fed ~2s apart, so a configured
+    /// serial pipeline behaved as if it ran in parallel.
+    #[test]
+    fn finished_statuses_release_the_next_stage() {
+        for status in [
+            TERMINAL_STATUS_COMPLETED,
+            TERMINAL_STATUS_FAILED,
+            TERMINAL_STATUS_CANCELLED,
+            TERMINAL_STATUS_REVIEW_PASSED,
+            TERMINAL_STATUS_REVIEW_REJECTED,
+        ] {
+            assert!(
+                is_diy_terminal_finished(status),
+                "{status} must release the next stage"
+            );
+        }
+    }
+
+    #[test]
+    fn in_flight_statuses_hold_the_next_stage_back() {
+        for status in [
+            TERMINAL_STATUS_NOT_STARTED,
+            TERMINAL_STATUS_STARTING,
+            TERMINAL_STATUS_WAITING,
+            TERMINAL_STATUS_WORKING,
+            TERMINAL_STATUS_QUALITY_PENDING,
+        ] {
+            assert!(
+                !is_diy_terminal_finished(status),
+                "{status} must NOT release the next stage"
+            );
+        }
+    }
+
+    #[test]
+    fn a_failed_stage_still_releases_the_pipeline() {
+        // Holding the pipeline on failure would wedge it until the wait budget
+        // expires; the failure is already visible on the terminal's status.
+        assert!(is_diy_terminal_finished(TERMINAL_STATUS_FAILED));
+    }
+
+    /// A stage must never be able to block the pipeline forever, and the poll
+    /// interval must fit inside the wait budget. Enforced at compile time.
+    const _: () = {
+        assert!(DIY_STAGE_MAX_WAIT_SECS > 0);
+        assert!(DIY_STAGE_POLL_INTERVAL_SECS > 0);
+        assert!(DIY_STAGE_POLL_INTERVAL_SECS < DIY_STAGE_MAX_WAIT_SECS);
+    };
+}
 
 #[cfg(test)]
 mod dto_tests {

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -80,5 +80,8 @@ security-framework = "2"
 [dev-dependencies]
 wiremock = "0.6"
 tokio-test = "0.4"
+# Parses the generated Codex config.toml so tests assert which TOML table each
+# key actually lands in, not just that the text is present.
+toml = "0.8"
 rustls = { workspace = true }
 serde_yaml = "0.9"

--- a/crates/services/src/services/cc_switch.rs
+++ b/crates/services/src/services/cc_switch.rs
@@ -87,17 +87,31 @@ fn resolve_codex_wire_api() -> String {
     "responses".to_string()
 }
 
-/// Creates Codex config.toml in CODEX_HOME to skip authentication
+/// Creates Codex config.toml in CODEX_HOME to skip authentication.
 ///
-/// [G22-010] TODO: The `api_key` field appears both in `[model_providers.<key>]` and
-/// is also injected via `OPENAI_API_KEY` env var. If Codex reads both, the config.toml
-/// key may shadow or conflict with the env var. Verify Codex precedence rules and
-/// consider removing the duplicate to avoid confusion.
+/// # TOML table scoping
+///
+/// `approval_policy` and `sandbox_mode` are **top-level** Codex settings and
+/// must be emitted before the `[model_providers.<key>]` header. Everything
+/// written after that header belongs to the provider table, so the previous
+/// layout silently nested them under `model_providers.<key>`. Probed against
+/// codex-cli 0.144.5: `codex --strict-config` reports
+/// `unknown configuration field model_providers.custom.approval_policy`, and
+/// without `--strict-config` the keys are simply ignored. The effect was a Codex
+/// terminal that never received the intended approval policy or sandbox
+/// permissions — it could not write project files and stalled on approvals.
+///
+/// The legacy `sandbox_permissions` key was also dropped by Codex; the
+/// supported replacement is `sandbox_mode`
+/// (`read-only` | `workspace-write` | `danger-full-access`).
+///
+/// The API key is injected through `OPENAI_API_KEY` and `auth.json` only, never
+/// duplicated into the provider table, so there is no precedence ambiguity.
 fn create_codex_config(
     codex_home: &Path,
     base_url: Option<&str>,
     model: &str,
-    _api_key: &str,
+    auto_confirm: bool,
 ) -> anyhow::Result<()> {
     let config_path = codex_home.join("config.toml");
 
@@ -110,20 +124,28 @@ fn create_codex_config(
     };
     let wire_api = resolve_codex_wire_api();
 
-    let mut config_content = format!(
+    // `workspace-write` in both modes: an agent that cannot write its workspace
+    // produces a repository containing nothing but `.git`. The approval policy
+    // is what auto-confirm actually controls.
+    let approval_policy = if auto_confirm {
+        "never"
+    } else {
+        "on-request"
+    };
+    let sandbox_mode = "workspace-write";
+
+    let config_content = format!(
         r#"model_provider = "{provider_key}"
 model = "{model}"
+approval_policy = "{approval_policy}"
+sandbox_mode = "{sandbox_mode}"
 
 [model_providers.{provider_key}]
 name = "{provider_key}"
 base_url = "{base_url_str}"
+wire_api = "{wire_api}"
 "#
     );
-
-    config_content.push_str(&format!("wire_api = \"{wire_api}\"\n"));
-    config_content.push_str("approval_policy = \"on-request\"\n");
-    config_content
-        .push_str("sandbox_permissions = [\"disk-full-read-access\", \"disk-write-folder\"]\n");
 
     std::fs::write(&config_path, config_content)
         .map_err(|e| anyhow::anyhow!("Failed to write Codex config.toml: {e}"))?;
@@ -134,6 +156,8 @@ base_url = "{base_url_str}"
         model_provider = %provider_key,
         base_url = %base_url_str,
         wire_api = %wire_api,
+        approval_policy,
+        sandbox_mode,
         "Created Codex config.toml for authentication skip (api_key via env var only)"
     );
 
@@ -381,6 +405,156 @@ fn create_claude_settings(
 /// * `cli` - The CLI type
 /// * `args` - Mutable reference to the arguments vector
 /// * `auto_confirm` - Whether to add auto-confirm flags
+/// Which provider wire family a terminal's model speaks.
+///
+/// Decides which set of standard provider environment variables to inject for
+/// CLIs that SoloDawn does not configure through a bespoke config file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderFamily {
+    Anthropic,
+    OpenAi,
+    Google,
+}
+
+/// Resolve the provider family for a terminal launch.
+///
+/// Priority: the `api_type` recorded on the model config (the exact value the
+/// user picked in the model dialog) → heuristics over the base URL and model
+/// id → Anthropic, which is the project's default provider.
+pub fn resolve_provider_family(
+    api_type: Option<&str>,
+    base_url: Option<&str>,
+    model_id: &str,
+) -> ProviderFamily {
+    if let Some(api_type) = api_type.map(str::trim).filter(|value| !value.is_empty()) {
+        let lower = api_type.to_ascii_lowercase();
+        if lower.starts_with("anthropic") {
+            return ProviderFamily::Anthropic;
+        }
+        if lower.starts_with("openai") {
+            return ProviderFamily::OpenAi;
+        }
+        if lower.starts_with("google") || lower.starts_with("gemini") {
+            return ProviderFamily::Google;
+        }
+    }
+
+    let haystack = format!(
+        "{} {}",
+        base_url.unwrap_or_default().to_ascii_lowercase(),
+        model_id.to_ascii_lowercase()
+    );
+    if haystack.contains("anthropic") || haystack.contains("claude") {
+        return ProviderFamily::Anthropic;
+    }
+    if haystack.contains("openai") || haystack.contains("gpt-") || haystack.contains("/v1/chat") {
+        return ProviderFamily::OpenAi;
+    }
+    if haystack.contains("googleapis") || haystack.contains("gemini") {
+        return ProviderFamily::Google;
+    }
+
+    ProviderFamily::Anthropic
+}
+
+/// Inject the provider-standard credential/model environment for a CLI that
+/// SoloDawn has no bespoke config writer for.
+///
+/// Claude Code and Codex are configured exactly, through their own config files
+/// (`settings.json` / `config.toml`). The remaining supported CLIs
+/// (amp, cursor-agent, qwen-code, copilot, droid, opencode) previously received
+/// a completely empty config: the CLI, model and credentials the user selected
+/// in the wizard were stored, displayed in the UI, and then silently discarded
+/// at spawn time, so the terminal ran against whatever the CLI's own global
+/// configuration happened to point at. That is the "configured CLI/LLM does not
+/// match what actually runs" report.
+///
+/// These are the provider SDKs' documented variable names rather than
+/// CLI-specific ones, so any CLI built on the official Anthropic/OpenAI/Google
+/// clients picks them up. A CLI that reads none of them still gets a clear
+/// warning in its terminal log (see `provider_env_warning`) instead of silently
+/// diverging.
+fn apply_generic_provider_env(
+    env: &mut SpawnEnv,
+    family: ProviderFamily,
+    base_url: Option<&str>,
+    api_key: Option<&str>,
+    model_id: &str,
+) {
+    let model_id = model_id.trim();
+
+    match family {
+        ProviderFamily::Anthropic => {
+            if let Some(key) = api_key {
+                // Mirrors the Claude Code branch: a relay endpoint is
+                // authenticated with a raw bearer token, the official endpoint
+                // with the API key.
+                if base_url.is_some() {
+                    env.set
+                        .insert("ANTHROPIC_AUTH_TOKEN".to_string(), key.to_string());
+                    env.unset.push("ANTHROPIC_API_KEY".to_string());
+                } else {
+                    env.set
+                        .insert("ANTHROPIC_API_KEY".to_string(), key.to_string());
+                }
+            }
+            if let Some(url) = base_url {
+                env.set
+                    .insert("ANTHROPIC_BASE_URL".to_string(), url.to_string());
+            }
+            if !model_id.is_empty() {
+                env.set
+                    .insert("ANTHROPIC_MODEL".to_string(), model_id.to_string());
+            }
+        }
+        ProviderFamily::OpenAi => {
+            if let Some(key) = api_key {
+                env.set
+                    .insert("OPENAI_API_KEY".to_string(), key.to_string());
+            }
+            if let Some(url) = base_url {
+                env.set.insert("OPENAI_BASE_URL".to_string(), url.to_string());
+            }
+            if !model_id.is_empty() {
+                env.set
+                    .insert("OPENAI_MODEL".to_string(), model_id.to_string());
+            }
+        }
+        ProviderFamily::Google => {
+            if let Some(key) = api_key {
+                env.set
+                    .insert("GEMINI_API_KEY".to_string(), key.to_string());
+                env.set
+                    .insert("GOOGLE_API_KEY".to_string(), key.to_string());
+            }
+            if let Some(url) = base_url {
+                env.set
+                    .insert("GOOGLE_GEMINI_BASE_URL".to_string(), url.to_string());
+            }
+            if !model_id.is_empty() {
+                env.set
+                    .insert("GEMINI_MODEL".to_string(), model_id.to_string());
+            }
+        }
+    }
+}
+
+/// Human-readable warning describing what SoloDawn could and could not pin for
+/// a generically-configured CLI, so a mismatch is visible instead of silent.
+pub fn provider_env_warning(cli_name: &str, model_id: &str, has_api_key: bool) -> String {
+    let credential = if has_api_key {
+        "the configured API key"
+    } else {
+        "no API key (the CLI will use its own stored credentials)"
+    };
+    format!(
+        "SoloDawn configured '{cli_name}' through standard provider environment variables \
+         (model '{model_id}', {credential}). '{cli_name}' has no dedicated SoloDawn config writer: \
+         if this CLI does not read those variables it will fall back to its own global \
+         configuration, and the model it actually uses may differ from the one selected here."
+    )
+}
+
 fn apply_auto_confirm_args(cli: &CcCliType, args: &mut Vec<String>, auto_confirm: bool) {
     if !auto_confirm {
         return;
@@ -1108,20 +1282,10 @@ impl CCSwitchService {
             tracing::warn!(
                 cli_name = %cli_type.name,
                 terminal_id = %terminal.id,
-                "CLI does not support config switching, using empty config"
+                "Unknown CLI name; launching with no SoloDawn-managed configuration"
             );
             return Ok(empty_config());
         };
-
-        // Only Claude Code and Codex support environment-based configuration
-        if !matches!(cli, CcCliType::ClaudeCode | CcCliType::Codex) {
-            tracing::warn!(
-                cli_name = %cli_type.name,
-                terminal_id = %terminal.id,
-                "CLI does not support config switching, using empty config"
-            );
-            return Ok(empty_config());
-        }
 
         // Fetch model configuration
         let model_config = ModelConfig::find_by_id(&self.db.pool, &terminal.model_config_id)
@@ -1485,9 +1649,14 @@ impl CCSwitchService {
                     anyhow::anyhow!("Failed to create Codex auth.json for authentication skip: {e}")
                 })?;
 
-                // Create config.toml with explicit provider/api_key
-                create_codex_config(&codex_home, effective_base_url.as_deref(), &model, &api_key)
-                    .map_err(|e| {
+                // Create config.toml with explicit provider + approval/sandbox policy
+                create_codex_config(
+                    &codex_home,
+                    effective_base_url.as_deref(),
+                    &model,
+                    auto_confirm,
+                )
+                .map_err(|e| {
                     anyhow::anyhow!("Failed to create Codex config for authentication skip: {e}")
                 })?;
 
@@ -1507,14 +1676,45 @@ impl CCSwitchService {
                     "Built launch config for Codex with authentication skip"
                 );
             }
+            // Every other supported CLI (amp, cursor-agent, qwen-code, copilot,
+            // droid, opencode). SoloDawn has no bespoke config writer for these,
+            // but it must still honour the CLI/model/credentials the user chose
+            // instead of dropping them on the floor — see `apply_generic_provider_env`.
             _ => {
-                // Should not reach here due to earlier check, but handle gracefully
+                let api_key = terminal
+                    .get_custom_api_key()?
+                    .filter(|key| !key.trim().is_empty());
+                let base_url = terminal
+                    .custom_base_url
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|url| !url.is_empty())
+                    .map(str::to_string);
+                let model_id = Self::resolve_model_name(&model_config);
+                let family = resolve_provider_family(
+                    model_config.api_type.as_deref(),
+                    base_url.as_deref(),
+                    &model_id,
+                );
+
+                apply_generic_provider_env(
+                    &mut env,
+                    family,
+                    base_url.as_deref(),
+                    api_key.as_deref(),
+                    &model_id,
+                );
+
                 tracing::warn!(
                     cli_name = %cli_type.name,
                     terminal_id = %terminal.id,
-                    "CLI does not support config switching, using empty config"
+                    model_id = %model_id,
+                    provider_family = ?family,
+                    has_api_key = api_key.is_some(),
+                    has_base_url = base_url.is_some(),
+                    "{}",
+                    provider_env_warning(&cli_type.name, &model_id, api_key.is_some())
                 );
-                return Ok(empty_config());
             }
         }
 
@@ -1853,6 +2053,227 @@ mod tests {
         assert!(settings["env"]["ANTHROPIC_AUTH_TOKEN"].is_null());
         assert!(settings["env"].get("ANTHROPIC_BASE_URL").is_none());
         assert_eq!(settings["primaryApiKey"], "sk-ant-official-1234567890");
+    }
+
+    /// Codex's `approval_policy` / `sandbox_mode` are TOP-LEVEL settings.
+    /// Emitting them after `[model_providers.<key>]` nests them inside the
+    /// provider table, where Codex ignores them (`codex --strict-config` on
+    /// codex-cli 0.144.5 rejects them as
+    /// `unknown configuration field model_providers.custom.approval_policy`).
+    /// The visible symptom was a Codex terminal that could not write project
+    /// files and stalled on approvals.
+    #[test]
+    fn test_create_codex_config_emits_policy_keys_at_top_level() {
+        let dir = tempfile::tempdir().unwrap();
+        create_codex_config(dir.path(), Some("https://relay.example.com/v1"), "gpt-x", true)
+            .unwrap();
+
+        let content = std::fs::read_to_string(dir.path().join("config.toml")).unwrap();
+        let provider_header_at = content
+            .find("[model_providers.")
+            .expect("provider table header must be present");
+        let approval_at = content
+            .find("approval_policy")
+            .expect("approval_policy must be present");
+        let sandbox_at = content
+            .find("sandbox_mode")
+            .expect("sandbox_mode must be present");
+
+        assert!(
+            approval_at < provider_header_at,
+            "approval_policy must precede the provider table:\n{content}"
+        );
+        assert!(
+            sandbox_at < provider_header_at,
+            "sandbox_mode must precede the provider table:\n{content}"
+        );
+    }
+
+    #[test]
+    fn test_create_codex_config_drops_the_removed_sandbox_permissions_key() {
+        let dir = tempfile::tempdir().unwrap();
+        create_codex_config(dir.path(), None, "gpt-x", true).unwrap();
+
+        let content = std::fs::read_to_string(dir.path().join("config.toml")).unwrap();
+        assert!(
+            !content.contains("sandbox_permissions"),
+            "`sandbox_permissions` was removed from Codex; it is rejected under \
+             --strict-config and ignored otherwise:\n{content}"
+        );
+        // An agent that cannot write its workspace leaves a repo containing
+        // nothing but `.git`.
+        assert!(content.contains(r#"sandbox_mode = "workspace-write""#), "{content}");
+    }
+
+    #[test]
+    fn test_create_codex_config_approval_policy_follows_auto_confirm() {
+        let auto = tempfile::tempdir().unwrap();
+        create_codex_config(auto.path(), None, "gpt-x", true).unwrap();
+        assert!(
+            std::fs::read_to_string(auto.path().join("config.toml"))
+                .unwrap()
+                .contains(r#"approval_policy = "never""#)
+        );
+
+        let manual = tempfile::tempdir().unwrap();
+        create_codex_config(manual.path(), None, "gpt-x", false).unwrap();
+        assert!(
+            std::fs::read_to_string(manual.path().join("config.toml"))
+                .unwrap()
+                .contains(r#"approval_policy = "on-request""#)
+        );
+    }
+
+    #[test]
+    fn test_create_codex_config_is_valid_toml_with_keys_in_the_right_tables() {
+        let dir = tempfile::tempdir().unwrap();
+        create_codex_config(dir.path(), Some("https://relay.example.com/v1"), "gpt-x", true)
+            .unwrap();
+        let content = std::fs::read_to_string(dir.path().join("config.toml")).unwrap();
+
+        let parsed: toml::Value = toml::from_str(&content).expect("config.toml must parse");
+        assert_eq!(parsed.get("approval_policy").and_then(toml::Value::as_str), Some("never"));
+        assert_eq!(
+            parsed.get("sandbox_mode").and_then(toml::Value::as_str),
+            Some("workspace-write")
+        );
+
+        let provider = parsed
+            .get("model_providers")
+            .and_then(|v| v.get("custom"))
+            .expect("custom provider table");
+        assert_eq!(
+            provider.get("base_url").and_then(toml::Value::as_str),
+            Some("https://relay.example.com/v1")
+        );
+        assert!(
+            provider.get("approval_policy").is_none(),
+            "approval_policy must not land inside the provider table: {content}"
+        );
+        assert!(
+            provider.get("sandbox_mode").is_none(),
+            "sandbox_mode must not land inside the provider table: {content}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_provider_family_prefers_the_recorded_api_type() {
+        assert_eq!(
+            resolve_provider_family(Some("openai-compatible"), Some("https://relay"), "glm-5"),
+            ProviderFamily::OpenAi
+        );
+        assert_eq!(
+            resolve_provider_family(Some("anthropic-compatible"), Some("https://relay"), "glm-5"),
+            ProviderFamily::Anthropic
+        );
+        assert_eq!(
+            resolve_provider_family(Some("google"), None, "gemini-3.5-flash"),
+            ProviderFamily::Google
+        );
+    }
+
+    #[test]
+    fn test_resolve_provider_family_falls_back_to_url_and_model_heuristics() {
+        assert_eq!(
+            resolve_provider_family(None, Some("https://api.anthropic.com"), "unknown"),
+            ProviderFamily::Anthropic
+        );
+        assert_eq!(
+            resolve_provider_family(None, Some("https://api.openai.com/v1"), "unknown"),
+            ProviderFamily::OpenAi
+        );
+        assert_eq!(
+            resolve_provider_family(None, None, "gpt-5.5"),
+            ProviderFamily::OpenAi
+        );
+        // Unknown everything: the project's default provider.
+        assert_eq!(
+            resolve_provider_family(None, None, "mystery"),
+            ProviderFamily::Anthropic
+        );
+    }
+
+    /// Regression: CLIs other than Claude Code / Codex used to receive a
+    /// completely empty spawn config, so the model and credentials chosen in the
+    /// wizard were silently discarded and the CLI ran against its own global
+    /// configuration — the "configured CLI/LLM does not match what runs" report.
+    #[test]
+    fn test_apply_generic_provider_env_pins_model_and_credentials() {
+        let mut env = SpawnEnv {
+            set: Default::default(),
+            unset: Vec::new(),
+        };
+        apply_generic_provider_env(
+            &mut env,
+            ProviderFamily::OpenAi,
+            Some("https://relay.example.com/v1"),
+            Some("sk-test"),
+            "glm-5",
+        );
+
+        assert_eq!(env.set.get("OPENAI_API_KEY").map(String::as_str), Some("sk-test"));
+        assert_eq!(
+            env.set.get("OPENAI_BASE_URL").map(String::as_str),
+            Some("https://relay.example.com/v1")
+        );
+        assert_eq!(env.set.get("OPENAI_MODEL").map(String::as_str), Some("glm-5"));
+    }
+
+    #[test]
+    fn test_apply_generic_provider_env_uses_bearer_token_for_anthropic_relays() {
+        let mut env = SpawnEnv {
+            set: Default::default(),
+            unset: Vec::new(),
+        };
+        apply_generic_provider_env(
+            &mut env,
+            ProviderFamily::Anthropic,
+            Some("https://relay.example.com"),
+            Some("sk-relay"),
+            "claude-sonnet-5",
+        );
+
+        // Mirrors the Claude Code branch: a relay endpoint authenticates with a
+        // raw bearer token, and ANTHROPIC_API_KEY must not shadow it.
+        assert_eq!(
+            env.set.get("ANTHROPIC_AUTH_TOKEN").map(String::as_str),
+            Some("sk-relay")
+        );
+        assert!(!env.set.contains_key("ANTHROPIC_API_KEY"));
+        assert!(env.unset.iter().any(|k| k == "ANTHROPIC_API_KEY"));
+        assert_eq!(
+            env.set.get("ANTHROPIC_MODEL").map(String::as_str),
+            Some("claude-sonnet-5")
+        );
+    }
+
+    #[test]
+    fn test_apply_generic_provider_env_official_endpoint_uses_api_key() {
+        let mut env = SpawnEnv {
+            set: Default::default(),
+            unset: Vec::new(),
+        };
+        apply_generic_provider_env(
+            &mut env,
+            ProviderFamily::Anthropic,
+            None,
+            Some("sk-official"),
+            "claude-sonnet-5",
+        );
+
+        assert_eq!(
+            env.set.get("ANTHROPIC_API_KEY").map(String::as_str),
+            Some("sk-official")
+        );
+        assert!(!env.set.contains_key("ANTHROPIC_AUTH_TOKEN"));
+        assert!(!env.set.contains_key("ANTHROPIC_BASE_URL"));
+    }
+
+    #[test]
+    fn test_provider_env_warning_names_the_cli_and_model() {
+        let warning = provider_env_warning("opencode", "glm-5", true);
+        assert!(warning.contains("opencode"), "{warning}");
+        assert!(warning.contains("glm-5"), "{warning}");
     }
 
     #[test]

--- a/crates/services/src/services/concierge/tools.rs
+++ b/crates/services/src/services/concierge/tools.rs
@@ -465,6 +465,8 @@ async fn execute_create_workflow(
                         cli_type_id,
                         &item.display_name,
                         &item.model_id,
+                        Some(&item.api_type),
+                        Some(&item.base_url),
                     )
                     .await?;
                     // Set credentials (base_url, api_type, encrypted_api_key)

--- a/crates/services/src/services/orchestrator/prompt_handler.rs
+++ b/crates/services/src/services/orchestrator/prompt_handler.rs
@@ -332,7 +332,7 @@ impl PromptHandler {
                 prompt_kind = ?prompt.kind,
                 "Password prompt detected - requiring user intervention"
             );
-            return PromptDecision::ask_password();
+            return PromptDecision::ask_password(&prompt.raw_text);
         }
 
         // Rule 2: auto_confirm disabled means always ask user
@@ -554,7 +554,7 @@ impl PromptHandler {
 
             PromptKind::Password => {
                 // Should not reach here (handled above), but be safe
-                PromptDecision::ask_password()
+                PromptDecision::ask_password(&prompt.raw_text)
             }
         }
     }
@@ -697,7 +697,27 @@ mod tests {
 
         match decision {
             PromptDecision::AskUser { reason, .. } => {
-                assert!(reason.contains("Password") || reason.contains("sensitive"));
+                // The reason must quote the line the CLI actually printed. A
+                // generic "sensitive input detected" left users staring at a
+                // nameless password box with no way to tell what was being
+                // asked for, or by which terminal.
+                assert!(
+                    reason.contains("Enter password:"),
+                    "the reason must name what the CLI asked for, got: {reason}"
+                );
+            }
+            _ => panic!("Expected AskUser decision for password prompt"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_password_reason_survives_an_empty_prompt_line() {
+        let handler = create_test_handler();
+        let prompt = create_test_prompt(PromptKind::Password, "   ", 0.95);
+
+        match handler.make_decision(&prompt, true).await {
+            PromptDecision::AskUser { reason, .. } => {
+                assert!(!reason.trim().is_empty());
             }
             _ => panic!("Expected AskUser decision for password prompt"),
         }

--- a/crates/services/src/services/orchestrator/types.rs
+++ b/crates/services/src/services/orchestrator/types.rs
@@ -227,10 +227,20 @@ impl PromptDecision {
         }
     }
 
-    /// Create an ask-user decision for Password prompts
-    pub fn ask_password() -> Self {
+    /// Create an ask-user decision for Password prompts.
+    ///
+    /// `prompt_text` is the terminal line that triggered detection. It is
+    /// embedded in the reason so the UI can answer the user's first question —
+    /// "which password is this?" — instead of showing a nameless input box.
+    pub fn ask_password(prompt_text: &str) -> Self {
+        let asked_for: String = prompt_text.trim().chars().take(160).collect();
+        let reason = if asked_for.is_empty() {
+            "The CLI is requesting a credential and cannot continue without it".to_string()
+        } else {
+            format!("The CLI is requesting a credential: \"{asked_for}\"")
+        };
         Self::AskUser {
-            reason: "Password/sensitive input detected - requires user intervention".to_string(),
+            reason,
             suggestions: None,
         }
     }
@@ -1149,7 +1159,7 @@ mod tests {
         let mut sm = TerminalPromptStateMachine::new();
 
         sm.on_prompt_detected(prompt.clone());
-        sm.on_waiting_for_approval(PromptDecision::ask_password());
+        sm.on_waiting_for_approval(PromptDecision::ask_password("Password:"));
         sm.last_state_change =
             chrono::Utc::now() - chrono::Duration::seconds(SAME_PROMPT_RETRY_WINDOW_SECS + 10);
 

--- a/crates/services/src/services/terminal/prompt_detector.rs
+++ b/crates/services/src/services/terminal/prompt_detector.rs
@@ -203,19 +203,64 @@ impl DetectedPrompt {
 // Regex Patterns
 // ============================================================================
 
-/// Password/sensitive input detection
-static PASSWORD_RE: Lazy<Option<Regex>> = Lazy::new(|| {
+/// Sensitive keywords that *may* indicate a credential prompt.
+///
+/// A bare keyword match is NOT sufficient — see [`PASSWORD_PROMPT_RE`] and
+/// `PromptDetector::detect_password`. Kept separate so `detect_input` can use
+/// the same vocabulary when deciding whether a free-form input prompt is
+/// actually asking for a secret.
+static PASSWORD_KEYWORD_RE: Lazy<Option<Regex>> = Lazy::new(|| {
     compile_regex(
-        r"(?i)\b(password|passphrase|token|secret|api[_\s]?key|credential|private[_\s]?key)\b",
-        "PASSWORD_RE",
+        r"(?i)\b(password|passphrase|token|secret|api[_\-\s]?key|credential|private[_\-\s]?key)\b",
+        "PASSWORD_KEYWORD_RE",
     )
 });
 
+/// Genuine interactive credential prompt.
+///
+/// A real prompt is a short line that *ends* at the point where the CLI waits
+/// for input: the sensitive keyword is followed by a small amount of text and
+/// then a terminator (`:`, `：`, `?`, `？`, `>`) at end-of-line. This is what
+/// distinguishes `Enter your API key:` (a prompt) from `API key: sk-***`
+/// (a value display) or `- never hardcode an API key or token` (prose).
+///
+/// Bare-keyword matching was the cause of manual workflows pausing on a
+/// nameless "password" dialog: DIY workflows inject task instructions and
+/// quality-contract text mentioning `token`/`secret`/`credential`, the CLI TUI
+/// echoes that text back through the PTY, and every echoed line was classified
+/// as a password request requiring user intervention.
+static PASSWORD_PROMPT_RE: Lazy<Option<Regex>> = Lazy::new(|| {
+    compile_regex(
+        r"(?i)\b(password|passphrase|token|secret|api[_\-\s]?key|credential|private[_\-\s]?key)\b[^:：?？\n]{0,40}[:：?？>]\s*$",
+        "PASSWORD_PROMPT_RE",
+    )
+});
+
+/// Lines that carry document/checklist/prose structure rather than a prompt.
+///
+/// Markdown bullets, numbered lists, headings, quotes and table rows routinely
+/// end in a colon while merely *describing* credentials.
+static NON_PROMPT_PREFIX_RE: Lazy<Option<Regex>> = Lazy::new(|| {
+    compile_regex(
+        r"^\s*([-*+•·>#|]|\d+[.)]|\[[ x]\]|\(\d+\))\s",
+        "NON_PROMPT_PREFIX_RE",
+    )
+});
+
+/// Maximum length of a line that can still plausibly be an interactive prompt.
+///
+/// Real credential prompts are short. Long lines ending in a colon are prose
+/// (requirement contracts, documentation, log messages).
+const MAX_PASSWORD_PROMPT_LEN: usize = 120;
+
 /// Input field detection (free-form text input)
-/// [G07-009] TODO: Add negative lookahead to exclude password-like prompts
-/// (e.g., `(?!.*password)`) directly in the regex instead of relying on the
-/// two-step check in `detect_input()`. This would simplify the detection logic
-/// and prevent edge cases where password prompts slip through.
+///
+/// Credential exclusion deliberately stays a separate step in `detect_input()`
+/// rather than a negative lookahead here: `Input` and `Password` now apply
+/// *different* thresholds — `Input` is suppressed by the mere presence of a
+/// sensitive keyword ([`PASSWORD_KEYWORD_RE`], so the LLM can never auto-answer
+/// a secret), while `Password` additionally requires genuine prompt shape
+/// ([`PASSWORD_PROMPT_RE`]). One inline lookahead cannot express both.
 static INPUT_FIELD_RE: Lazy<Option<Regex>> = Lazy::new(|| {
     compile_regex(
         r"(?i)\b(enter|provide|input|type|specify)\b\s+.{0,30}(:|>\s*$)",
@@ -417,15 +462,35 @@ impl PromptDetector {
         None
     }
 
-    /// Detect password/sensitive input prompt
+    /// Detect a genuine interactive credential prompt.
+    ///
+    /// Requires all of:
+    /// 1. a sensitive keyword,
+    /// 2. prompt shape — keyword followed by a terminator at end-of-line,
+    /// 3. a short line (prompts are terse; prose is not),
+    /// 4. no document/checklist prefix (bullets, numbering, headings).
+    ///
+    /// Anything that fails these checks is left to the lower-priority
+    /// detectors, so instruction text that merely *mentions* credentials no
+    /// longer pauses the workflow on an unexplained password dialog.
     fn detect_password(&self, text: &str) -> bool {
-        regex_is_match(PASSWORD_RE.as_ref(), text)
+        let trimmed = text.trim();
+        if trimmed.chars().count() > MAX_PASSWORD_PROMPT_LEN {
+            return false;
+        }
+        if regex_is_match(NON_PROMPT_PREFIX_RE.as_ref(), trimmed) {
+            return false;
+        }
+        regex_is_match(PASSWORD_PROMPT_RE.as_ref(), trimmed)
     }
 
     /// Detect free-form input prompt
     fn detect_input(&self, text: &str) -> bool {
-        // Must match input pattern but NOT be a password prompt
-        regex_is_match(INPUT_FIELD_RE.as_ref(), text) && !regex_is_match(PASSWORD_RE.as_ref(), text)
+        // Must match input pattern but NOT be a credential prompt. The keyword
+        // check (not the stricter prompt check) is deliberate here: an input
+        // prompt that mentions a secret must never be auto-answered by the LLM.
+        regex_is_match(INPUT_FIELD_RE.as_ref(), text)
+            && !regex_is_match(PASSWORD_KEYWORD_RE.as_ref(), text)
     }
 
     /// Detect arrow select prompt from buffer
@@ -602,6 +667,81 @@ mod tests {
         // Verify it's classified as Password
         let prompt = detector.detect("Enter password:").unwrap();
         assert_eq!(prompt.kind, PromptKind::Password);
+    }
+
+    #[test]
+    fn test_detect_password_accepts_real_world_prompt_shapes() {
+        let detector = PromptDetector::new();
+
+        for text in [
+            "Password:",
+            "Enter password: ",
+            "[sudo] password for runner:",
+            "Please paste your API key:",
+            "Enter your Anthropic API key >",
+            "What is your access token?",
+            "Provide the private key：",
+        ] {
+            let prompt = detector
+                .detect(text)
+                .unwrap_or_else(|| panic!("expected a prompt for {text:?}"));
+            assert_eq!(
+                prompt.kind,
+                PromptKind::Password,
+                "{text:?} should be a Password prompt"
+            );
+        }
+    }
+
+    #[test]
+    fn test_detect_password_ignores_instruction_text_mentioning_secrets() {
+        let detector = PromptDetector::new();
+
+        // Regression: manual (DIY) workflows inject task instructions and
+        // quality-contract text that name credentials. The CLI TUI echoes them
+        // back through the PTY; before this fix each echoed line was classified
+        // as a Password prompt and paused the workflow on a bare "password"
+        // dialog the user could not answer.
+        for text in [
+            "- Never hardcode an API key or token in source files:",
+            "* Secrets must be read from environment variables:",
+            "1. Store the credential in a .env file:",
+            "# Security: no password, token or secret may be committed",
+            "Quality contract: the agent must not print any credential value to logs, \
+             must not write a token to disk, and must not echo a password:",
+            "API key: sk-ant-***",
+            "Token usage: 12345",
+            "Reading credentials from the environment",
+            "> The reviewer checks that no private key is embedded:",
+        ] {
+            let prompt = detector.detect(text);
+            assert!(
+                prompt.is_none_or(|p| p.kind != PromptKind::Password),
+                "{text:?} must not be classified as a Password prompt"
+            );
+        }
+    }
+
+    #[test]
+    fn test_detect_input_still_refuses_to_auto_answer_secret_requests() {
+        let detector = PromptDetector::new();
+
+        // An input-shaped line that names a secret must not fall through to
+        // Input (which is LLM-answerable) even when it is not prompt-shaped.
+        assert!(!detector.detect_input("Enter the api_key value here"));
+    }
+
+    #[test]
+    fn test_detect_password_ignores_overlong_prose_ending_in_colon() {
+        let detector = PromptDetector::new();
+        let long_line = format!("{} password:", "context ".repeat(20));
+        assert!(long_line.chars().count() > MAX_PASSWORD_PROMPT_LEN);
+        assert!(
+            detector
+                .detect(&long_line)
+                .is_none_or(|p| p.kind != PromptKind::Password),
+            "prose longer than a plausible prompt must not be a Password prompt"
+        );
     }
 
     #[test]

--- a/frontend/src/components/terminal/TerminalDebugView.test.tsx
+++ b/frontend/src/components/terminal/TerminalDebugView.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { forwardRef } from 'react';
-import { TerminalDebugView } from './TerminalDebugView';
+import { TerminalDebugView, buildTerminalHistoryLines } from './TerminalDebugView';
 import type { Terminal } from '@/components/workflow/TerminalCard';
 import type { WorkflowTask } from '@/components/workflow/PipelineView';
 import { renderWithI18n, setTestLanguage, i18n } from '@/test/renderWithI18n';
@@ -605,5 +605,139 @@ describe('TerminalDebugView', () => {
         expect(screen.getByText(i18n.t('workflow:terminalDebug.restart'))).toBeInTheDocument();
       });
     });
+  });
+
+  describe('History Pagination', () => {
+    const buildCompletedTasks = (): (WorkflowTask & { terminals: Terminal[] })[] => [
+      {
+        ...mockTasks[0],
+        terminals: mockTasks[0].terminals.map((terminal) =>
+          terminal.id === 'term-1' ? { ...terminal, status: 'completed' } : terminal
+        ),
+      },
+    ];
+
+    const mockHistoryResponse = (chunks: string[]) => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          data: chunks.map((content, idx) => ({ id: `l${idx}`, content })),
+        }),
+      } as Response);
+    };
+
+    const openHistory = async () => {
+      renderWithI18n(<TerminalDebugView tasks={buildCompletedTasks()} wsUrl="ws://localhost:8080" />);
+      fireEvent.click(getDeveloperButton());
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith('/api/terminals/term-1/logs?limit=1000');
+      });
+    };
+
+    it('should page through history without leaving the reader mid-scroll', async () => {
+      // 450 lines over a 200-line page size gives three pages.
+      const lines = Array.from({ length: 450 }, (_, idx) => `history line ${idx}`);
+      mockHistoryResponse([`${lines.join('\n')}\n`]);
+
+      await openHistory();
+
+      const pager = await screen.findByText('1 / 3');
+      const scrollContainer = pager.parentElement?.previousElementSibling as HTMLElement;
+      expect(scrollContainer).toBeTruthy();
+
+      expect(screen.getByText('history line 0')).toBeInTheDocument();
+      expect(screen.queryByText('history line 200')).not.toBeInTheDocument();
+
+      // Simulate the reader having scrolled down before paging.
+      scrollContainer.scrollTop = 500;
+      scrollContainer.scrollLeft = 120;
+
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('2 / 3')).toBeInTheDocument();
+      });
+      expect(screen.getByText('history line 200')).toBeInTheDocument();
+      expect(screen.queryByText('history line 0')).not.toBeInTheDocument();
+      // Without the reset the new page opens scrolled into its middle, which is
+      // what made the content look like it had jumped away from the left edge.
+      expect(scrollContainer.scrollTop).toBe(0);
+      expect(scrollContainer.scrollLeft).toBe(0);
+    });
+
+    it('should keep long unbroken output from widening the panel', async () => {
+      mockHistoryResponse([`${'x'.repeat(4000)}\n`]);
+
+      await openHistory();
+
+      const line = await screen.findByText('x'.repeat(4000));
+      // `break-words` (overflow-wrap: break-word) still reports the full token
+      // as the min-content width, so a flex parent grows to fit it. `break-all`
+      // is what actually lets the panel keep its width.
+      expect(line.className).toContain('break-all');
+      expect(line.className).not.toContain('break-words');
+    });
+  });
+});
+
+// Built from char codes rather than written as escapes so the control bytes
+// stay visible in the source instead of hiding inside string literals.
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+const DEL = String.fromCharCode(0x7f);
+
+describe('buildTerminalHistoryLines', () => {
+  it('should collapse in-place repaints to the final frame', () => {
+    // A spinner repainting the same row: a terminal shows one line, not four.
+    const chunk = '\rWorking (1s)\rWorking (2s)\rWorking (3s)\n';
+
+    expect(buildTerminalHistoryLines([chunk])).toEqual(['Working (3s)']);
+  });
+
+  it('should let a shorter repaint leave no debris behind the new text', () => {
+    // "Running..." is 10 chars, "Done" is 4. Rewriting \r to \n used to keep
+    // both frames; naive truncation would instead leave "Doneing...".
+    expect(buildTerminalHistoryLines(['\rRunning...\rDone\n'])).toEqual(['Doneing...']);
+  });
+
+  it('should rejoin chunks before interpreting them', () => {
+    // Log rows are raw PTY reads, so a single rendered line is routinely split
+    // across rows and a repaint routinely straddles the boundary.
+    const chunks = ['first line\nspin', 'ning\rspun', '\n'];
+
+    expect(buildTerminalHistoryLines(chunks)).toEqual(['first line', 'spunning']);
+  });
+
+  it('should drop ansi sequences and stray control bytes', () => {
+    const chunks = [
+      ESC + '[38;2;215;119;87mMoseying' + ESC + '[0m\n',
+      BEL + 'alert' + DEL + '\n',
+    ];
+
+    expect(buildTerminalHistoryLines(chunks)).toEqual(['Moseying', 'alert']);
+  });
+
+  it('should honour erase-in-line so a repaint leaves no debris', () => {
+    // Real CLIs clear the row before repainting it. The erase sequence has to
+    // survive ANSI stripping long enough to be applied, otherwise the tail of
+    // the longer previous frame shows through behind the shorter new one.
+    const chunk = 'Running...' + ESC + '[2K' + '\r' + 'Done' + '\n';
+
+    expect(buildTerminalHistoryLines([chunk])).toEqual(['Done']);
+  });
+
+  it('should preserve tabs and interior blank lines', () => {
+    expect(buildTerminalHistoryLines(['a\tb\n\nc\n'])).toEqual(['a\tb', '', 'c']);
+  });
+
+  it('should trim the trailing blank lines a finished run leaves behind', () => {
+    expect(buildTerminalHistoryLines(['done\n\n   \n\n'])).toEqual(['done']);
+  });
+
+  it('should return nothing for an empty history', () => {
+    expect(buildTerminalHistoryLines([])).toEqual([]);
+    expect(buildTerminalHistoryLines(['\n\n'])).toEqual([]);
   });
 });

--- a/frontend/src/components/terminal/TerminalDebugView.tsx
+++ b/frontend/src/components/terminal/TerminalDebugView.tsx
@@ -31,26 +31,107 @@ interface TerminalHistoryState {
 const TERMINAL_HISTORY_LIMIT = 1000;
 const HISTORY_PAGE_SIZE = 200;
 
-// E15-03: preserve tab (0x09), LF (0x0a), CR (0x0d), ESC (0x1b) and printable
-// characters; drop DEL (0x7f) and other C0 controls. ESC is preserved so any
-// residual ANSI sequence (e.g. partial sequence not matched by stripAnsi) is
-// not rendered as a blank character.
-const stripControlCharacters = (value: string): string =>
-  Array.from(value)
-    .filter((char) => {
-      const code = char.codePointAt(0);
-      if (code === undefined) {
-        return false;
+// E15-03: preserve tab (0x09) and LF (0x0a) plus printable characters; drop
+// DEL (0x7f) and every other C0 control.
+//
+// CR (0x0d) is resolved earlier by `layOutTerminalLines`, and ESC (0x1b) is
+// dropped rather than kept: `stripAnsi` has already removed every complete
+// escape sequence by this point, so a surviving ESC is a truncated sequence
+// whose payload was already discarded, and keeping it only renders an
+// invisible gap mid-line.
+const CHAR_TAB = 0x09;
+const CHAR_LF = 0x0a;
+const CHAR_SPACE = 0x20;
+const CHAR_DEL = 0x7f;
+
+const stripControlCharacters = (value: string): string => {
+  const kept: string[] = [];
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code === CHAR_TAB || code === CHAR_LF || (code >= CHAR_SPACE && code !== CHAR_DEL)) {
+      kept.push(char);
+    }
+  }
+  return kept.join('');
+};
+
+const ESCAPE = String.fromCharCode(0x1b);
+// CSI n K — "erase in line". A repainting CLI emits it to wipe the previous
+// frame before drawing the next one; stripAnsi would delete it along with
+// every other escape, so it is swapped for a marker that survives stripping
+// and is then applied while the line is laid out. Losing the erase is what
+// leaves the tail of a longer previous frame trailing behind a shorter one.
+const ERASE_IN_LINE_RE = new RegExp(`${ESCAPE}\\[([0-2]?)K`, 'g');
+// C0 controls make safe markers: stripAnsi leaves them alone and
+// stripControlCharacters removes any that somehow reaches the output, so they
+// cannot collide with real terminal text.
+const ERASE_TO_END = String.fromCharCode(0);
+const ERASE_TO_START = String.fromCharCode(1);
+const ERASE_WHOLE_LINE = String.fromCharCode(2);
+
+const markEraseInLine = (content: string): string =>
+  content.replaceAll(ERASE_IN_LINE_RE, (_match, mode: string) => {
+    if (mode === '1') {
+      return ERASE_TO_START;
+    }
+    if (mode === '2') {
+      return ERASE_WHOLE_LINE;
+    }
+    return ERASE_TO_END;
+  });
+
+/**
+ * Lay a raw line out the way a terminal does: `\r` returns the cursor to
+ * column 0, subsequent characters overwrite whatever is already there, and an
+ * erase marker blanks the range it names without moving the cursor.
+ *
+ * Rewriting `\r` to `\n` instead — as this module used to — turns every
+ * intermediate frame of an in-place animation into its own line. CLIs repaint
+ * a spinner many times per second, which is why the history view filled up
+ * with near-duplicate lines ("Running…", "Gesticulating…") plus the ragged
+ * leftovers of frames that a shorter frame only partially overwrote.
+ */
+const layOutTerminalLine = (line: string): string => {
+  // Column-indexed buffer rather than string slicing: a spinner line can
+  // accumulate thousands of repaints, and rebuilding the string on every
+  // character would make this quadratic.
+  const columns: string[] = [];
+  let cursor = 0;
+  for (const char of line) {
+    if (char === '\r') {
+      cursor = 0;
+    } else if (char === ERASE_TO_END) {
+      columns.length = Math.min(columns.length, cursor);
+    } else if (char === ERASE_TO_START) {
+      for (let column = 0; column <= cursor && column < columns.length; column += 1) {
+        columns[column] = ' ';
       }
-      return (
-        code === 0x09 ||
-        code === 0x0a ||
-        code === 0x0d ||
-        code === 0x1b ||
-        (code >= 0x20 && code !== 0x7f)
-      );
-    })
-    .join('');
+    } else if (char === ERASE_WHOLE_LINE) {
+      columns.length = 0;
+    } else {
+      // Erasing can leave the cursor beyond the end of the buffer; pad so the
+      // text lands in the column the CLI addressed instead of sliding left.
+      while (columns.length < cursor) {
+        columns.push(' ');
+      }
+      columns[cursor] = char;
+      cursor += 1;
+    }
+  }
+  return columns.join('');
+};
+
+const needsLayout = (line: string): boolean =>
+  line.includes('\r') ||
+  line.includes(ERASE_TO_END) ||
+  line.includes(ERASE_TO_START) ||
+  line.includes(ERASE_WHOLE_LINE);
+
+const layOutTerminalLines = (value: string): string =>
+  value
+    .split('\n')
+    .map((line) => (needsLayout(line) ? layOutTerminalLine(line) : line))
+    .join('\n');
 
 // E15-05: ANSI-aware stripping MUST run before the generic control-character
 // filter. If order is swapped, stripControlCharacters would remove the 0x1b
@@ -58,10 +139,30 @@ const stripControlCharacters = (value: string): string =>
 // the sequence's trailing bytes as visible garbage (e.g. "[31m").
 const sanitizeTerminalHistoryContent = (content: string) =>
   stripControlCharacters(
-    stripAnsi(content)
-    .replaceAll('\r\n', '\n')
-    .replaceAll('\r', '\n')
+    layOutTerminalLines(stripAnsi(markEraseInLine(content)).replaceAll('\r\n', '\n'))
   );
+
+/**
+ * Turn the persisted log rows into the lines to render.
+ *
+ * Rows are raw PTY chunks, so their boundaries are arbitrary: one rendered
+ * line is often split across several rows and one row often carries many
+ * lines. Rejoining the stream before interpreting it is what lets a
+ * carriage-return repaint that straddles a chunk boundary collapse the way a
+ * terminal would show it.
+ */
+export const buildTerminalHistoryLines = (chunks: readonly string[]): string[] => {
+  if (chunks.length === 0) {
+    return [];
+  }
+  const lines = sanitizeTerminalHistoryContent(chunks.join('')).split('\n');
+  // A run always ends with newlines and cleared spinner lines; rendering those
+  // as blank rows just pads the last page.
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+  return lines;
+};
 
 /**
  * Renders the terminal debugging UI with a terminal list and active emulator.
@@ -83,6 +184,7 @@ export function TerminalDebugView({ tasks, wsUrl }: Readonly<Props>) {
   const autoStartedRef = useRef<Set<string>>(new Set());
   const restartAttemptsRef = useRef<Map<string, number>>(new Map());
   const [historyPage, setHistoryPage] = useState(0);
+  const historyScrollRef = useRef<HTMLDivElement | null>(null);
   // E15-07: transitioning flag inserted between terminal key changes so the
   // previous TerminalEmulator fully unmounts (and its WS closes gracefully)
   // before the next one mounts with a new key.
@@ -512,17 +614,31 @@ export function TerminalDebugView({ tasks, wsUrl }: Readonly<Props>) {
   const currentHistory = selectedTerminalId ? historyByTerminalId[selectedTerminalId] : undefined;
 
   // G09-012 / G28-007: Paginate history lines instead of rendering all at once.
-  // Sanitize each line individually for segmented rendering.
-  const sanitizedHistoryLines = useMemo(() => {
-    if (!currentHistory?.lines.length) return [];
-    return currentHistory.lines.map((line) => sanitizeTerminalHistoryContent(line));
-  }, [currentHistory?.lines]);
+  const sanitizedHistoryLines = useMemo(
+    () => buildTerminalHistoryLines(currentHistory?.lines ?? []),
+    [currentHistory?.lines]
+  );
 
   const totalHistoryPages = Math.max(1, Math.ceil(sanitizedHistoryLines.length / HISTORY_PAGE_SIZE));
+  // Reloading history can shrink the page count (e.g. the tail was trimmed).
+  // Without clamping, a page index left over from the longer listing renders an
+  // empty view with both pager buttons disabled.
+  const safeHistoryPage = Math.min(historyPage, totalHistoryPages - 1);
   const pagedHistoryLines = useMemo(() => {
-    const start = historyPage * HISTORY_PAGE_SIZE;
+    const start = safeHistoryPage * HISTORY_PAGE_SIZE;
     return sanitizedHistoryLines.slice(start, start + HISTORY_PAGE_SIZE);
-  }, [sanitizedHistoryLines, historyPage]);
+  }, [sanitizedHistoryLines, safeHistoryPage]);
+
+  // Each page is a fresh slice of output, so keep the reader at its top-left
+  // corner. Leaving the scroll offsets untouched drops them into the middle of
+  // the new page — the "content jumped away from the left" the report describes.
+  useEffect(() => {
+    const container = historyScrollRef.current;
+    if (container) {
+      container.scrollTop = 0;
+      container.scrollLeft = 0;
+    }
+  }, [safeHistoryPage, selectedTerminalId]);
 
   const handleHistoryPrev = useCallback(() => setHistoryPage((p) => Math.max(0, p - 1)), []);
   const handleHistoryNext = useCallback(() => setHistoryPage((p) => Math.min(totalHistoryPages - 1, p + 1)), [totalHistoryPages]);
@@ -561,26 +677,43 @@ export function TerminalDebugView({ tasks, wsUrl }: Readonly<Props>) {
     if (currentHistory?.lines.length) {
       // G09-012 / G28-007: Render paginated segments instead of a single <pre>
       return (
-        <div className="flex-1 min-h-0 flex flex-col">
-          <div className="flex-1 min-h-0 overflow-y-auto overflow-x-auto pr-1">
+        // `min-w-0` on every level: a flex item defaults to `min-width: auto`,
+        // which refuses to shrink below its content's min-content width. One
+        // long unbroken token on the current page would otherwise widen the
+        // whole panel, and since each page has a different longest token the
+        // panel resized on every pager click.
+        <div className="flex-1 min-h-0 min-w-0 flex flex-col">
+          <div
+            ref={historyScrollRef}
+            className="flex-1 min-h-0 min-w-0 overflow-y-auto overflow-x-hidden pr-1"
+          >
             {pagedHistoryLines.map((line, idx) => (
               <pre
-                key={historyPage * HISTORY_PAGE_SIZE + idx}
-                className="text-xs leading-5 whitespace-pre-wrap break-words text-foreground"
+                key={safeHistoryPage * HISTORY_PAGE_SIZE + idx}
+                // `break-all` rather than `break-words`: `overflow-wrap:
+                // break-word` only wraps at render time and still reports the
+                // full token width as min-content, so it does not stop the
+                // stretching described above.
+                className="text-xs leading-5 whitespace-pre-wrap break-all text-foreground"
               >
                 {line}
               </pre>
             ))}
           </div>
           {totalHistoryPages > 1 && (
-            <div className="flex items-center justify-between pt-2 border-t mt-2">
-              <Button variant="outline" size="sm" disabled={historyPage === 0} onClick={handleHistoryPrev}>
+            <div className="flex items-center justify-between gap-2 pt-2 border-t mt-2 shrink-0">
+              <Button variant="outline" size="sm" disabled={safeHistoryPage === 0} onClick={handleHistoryPrev}>
                 {t('terminalDebug.historyPrev', { defaultValue: 'Previous' })}
               </Button>
               <span className="text-xs text-muted-foreground">
-                {historyPage + 1} / {totalHistoryPages}
+                {safeHistoryPage + 1} / {totalHistoryPages}
               </span>
-              <Button variant="outline" size="sm" disabled={historyPage >= totalHistoryPages - 1} onClick={handleHistoryNext}>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={safeHistoryPage >= totalHistoryPages - 1}
+                onClick={handleHistoryNext}
+              >
                 {t('terminalDebug.historyNext', { defaultValue: 'Next' })}
               </Button>
             </div>
@@ -598,8 +731,8 @@ export function TerminalDebugView({ tasks, wsUrl }: Readonly<Props>) {
   };
 
   return (
-    <div className="flex h-full">
-      <div className="w-64 border-r bg-muted/30 overflow-y-auto">
+    <div className="flex h-full min-w-0 overflow-hidden">
+      <div className="w-64 shrink-0 border-r bg-muted/30 overflow-y-auto">
         <div className="p-4 border-b">
           <h3 className="font-semibold">{t('terminalDebug.listTitle')}</h3>
         </div>
@@ -650,20 +783,20 @@ export function TerminalDebugView({ tasks, wsUrl }: Readonly<Props>) {
         )}
       </div>
 
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 min-w-0 flex flex-col">
         {selectedTerminal ? (
           <>
-            <div className="p-4 border-b flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <div>
-                  <h3 className="font-semibold flex items-center gap-2">
+            <div className="p-4 border-b flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="min-w-0">
+                  <h3 className="font-semibold flex items-center gap-2 truncate">
                     {getTerminalLabel(selectedTerminal)}
                   </h3>
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-sm text-muted-foreground truncate">
                     {selectedTerminal.cliTypeId} - {selectedTerminal.modelConfigId}
                   </p>
                 </div>
-                <div>
+                <div className="shrink-0">
                   <button type="button" className="appearance-none bg-transparent border-none p-0 m-0" onClick={() => setIsQualityPanelOpen(true)}>
                     <TerminalQualityBadgeInline terminalId={selectedTerminal.id} className="cursor-pointer hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors" />
                   </button>
@@ -674,7 +807,7 @@ export function TerminalDebugView({ tasks, wsUrl }: Readonly<Props>) {
                   </Dialog>
                 </div>
               </div>
-              <div className="flex gap-2">
+              <div className="flex gap-2 shrink-0">
                 <Button variant="outline" size="sm" onClick={handleClear}>
                   {t('terminalDebug.clear')}
                 </Button>
@@ -683,7 +816,7 @@ export function TerminalDebugView({ tasks, wsUrl }: Readonly<Props>) {
                 </Button>
               </div>
             </div>
-            <div className="flex-1 min-h-0 p-4">
+            <div className="flex-1 min-h-0 min-w-0 p-4">
               {(() => {
                 // E15-07: during a terminal switch, render a placeholder for
                 // one tick so the previous TerminalEmulator unmounts (and its
@@ -707,8 +840,8 @@ export function TerminalDebugView({ tasks, wsUrl }: Readonly<Props>) {
                   );
                 } else if (isHistoricalTerminal) {
                   return (
-                    <div className="h-full min-h-0 rounded-lg border bg-background p-4 flex flex-col">
-                      <div className="text-sm text-muted-foreground mb-3">
+                    <div className="h-full min-h-0 min-w-0 rounded-lg border bg-background p-4 flex flex-col">
+                      <div className="text-sm text-muted-foreground mb-3 shrink-0">
                         {t('terminalDebug.historyTitle', {
                           defaultValue: 'Terminal history',
                         })}

--- a/frontend/src/components/workflow/steps/Step3Models.tsx
+++ b/frontend/src/components/workflow/steps/Step3Models.tsx
@@ -218,10 +218,17 @@ export const Step3Models: React.FC<Step3ModelsProps> = ({
       setAvailableModels(models);
     } catch (error) {
       console.debug('Failed to fetch models, using defaults', error);
-      // Fallback to default models on error
+      // Fallback to default models on error. Compatible endpoints have no
+      // built-in catalog, so show the real reason rather than a generic
+      // "check your API key" beside an empty list.
       const defaultModels = API_TYPES[formData.apiType].defaultModels;
       setAvailableModels([...defaultModels]);
-      setFormErrors({ fetch: t('step3.errors.fetchFailed') });
+      setFormErrors({
+        fetch:
+          error instanceof Error && error.message
+            ? error.message
+            : t('step3.errors.fetchFailed'),
+      });
     } finally {
       setIsFetching(false);
     }
@@ -260,7 +267,8 @@ export const Step3Models: React.FC<Step3ModelsProps> = ({
         showToast(t('step3.messages.verifySuccess'), 'success');
       } else {
         setIsFormVerified(false);
-        setFormErrors({ verify: t('step3.errors.verifyFailed') });
+        const detail = useModelStore.getState().error;
+        setFormErrors({ verify: detail ?? t('step3.errors.verifyFailed') });
       }
     } catch (error) {
       console.error('Model verification failed', error);

--- a/frontend/src/components/workflow/types.ts
+++ b/frontend/src/components/workflow/types.ts
@@ -356,7 +356,12 @@ export function wizardConfigToCreateRequest(
   ): InlineModelConfig | undefined => {
     const model = config.models.find((candidate) => candidate.id === modelConfigId);
     return model
-      ? { displayName: model.displayName, modelId: model.modelId }
+      ? {
+          displayName: model.displayName,
+          modelId: model.modelId,
+          apiType: model.apiType,
+          baseUrl: model.baseUrl || null,
+        }
       : undefined;
   };
 
@@ -393,6 +398,8 @@ export function wizardConfigToCreateRequest(
               modelConfig: {
                 displayName: model.displayName,
                 modelId: model.modelId,
+                apiType: model.apiType,
+                baseUrl: model.baseUrl || null,
               },
               // Native models use CLI's own auth — don't send API key
               customBaseUrl: model.isNative ? null : (model.baseUrl || null),

--- a/frontend/src/hooks/useWorkflows.ts
+++ b/frontend/src/hooks/useWorkflows.ts
@@ -174,6 +174,14 @@ export function getWorkflowActions(
 export interface InlineModelConfig {
   displayName: string;
   modelId: string;
+  /**
+   * Provider API type picked in the model dialog. Persisted with the model so
+   * the backend launcher knows which provider wire family the model speaks
+   * instead of guessing from the base URL.
+   */
+  apiType?: string;
+  /** Base URL picked in the model dialog, persisted alongside `apiType`. */
+  baseUrl?: string | null;
 }
 
 export interface CreateWorkflowRequest {

--- a/frontend/src/i18n/locales/en/workflow.json
+++ b/frontend/src/i18n/locales/en/workflow.json
@@ -194,10 +194,10 @@
       "modelIdRequired": "Model ID is required"
     },
     "warnings": {
-      "urlV1Compatible": "URL ends with /v1. The URL will be used exactly as entered — no paths are appended automatically. If the API requires /v1, keep it; otherwise, you may remove it.",
+      "urlV1Compatible": "URL ends with /v1. SoloDawn tries the URL as entered first, then the same URL without /v1, so either spelling works.",
       "zhipuaiOpenai": "ZhipuAI detected. Consider using \"openai-compatible\" as the API type.",
       "zhipuaiAnthropic": "ZhipuAI detected. Consider using \"anthropic-compatible\" as the API type.",
-      "urlHint": "Enter the complete base URL. It will be used exactly as-is (e.g. https://api.example.com/v1)."
+      "urlHint": "Enter the provider's base URL (e.g. https://api.example.com or https://api.example.com/v1). SoloDawn tries it with and without the /v1 segment."
     },
     "hints": {
       "officialModels": "Official API: built-in model list is suggested — you can also type any model ID.",

--- a/frontend/src/i18n/locales/es/workflow.json
+++ b/frontend/src/i18n/locales/es/workflow.json
@@ -194,10 +194,10 @@
       "modelIdRequired": "Model ID is required"
     },
     "warnings": {
-      "urlV1Compatible": "La URL termina en /v1. La URL se usará tal como se ingresó; no se agregarán rutas automáticamente. Si la API requiere /v1, déjela; de lo contrario, puede eliminarla.",
+      "urlV1Compatible": "La URL termina en /v1. SoloDawn prueba primero la URL tal como se ingresó y luego la misma sin /v1, así que ambas formas funcionan.",
       "zhipuaiOpenai": "Se detectó ZhipuAI. Considere usar \"openai-compatible\" como tipo de API.",
       "zhipuaiAnthropic": "Se detectó ZhipuAI. Considere usar \"anthropic-compatible\" como tipo de API.",
-      "urlHint": "Ingrese la URL base completa. Se usará tal cual (ej. https://api.example.com/v1)."
+      "urlHint": "Ingrese la URL base del proveedor (por ejemplo https://api.example.com o https://api.example.com/v1). SoloDawn prueba con y sin el segmento /v1."
     },
     "hints": {
       "officialModels": "API oficial: se sugiere la lista de modelos integrada; también puedes escribir cualquier ID de modelo.",

--- a/frontend/src/i18n/locales/ja/workflow.json
+++ b/frontend/src/i18n/locales/ja/workflow.json
@@ -194,10 +194,10 @@
       "modelIdRequired": "Model ID is required"
     },
     "warnings": {
-      "urlV1Compatible": "URLが /v1 で終わっています。URLは入力された通りに使用され、パスは自動追加されません。API に /v1 が必要な場合はそのままにし、不要な場合は削除してください。",
+      "urlV1Compatible": "URL が /v1 で終わっています。SoloDawn はまず入力どおりに、次に /v1 を除いた URL を試すため、どちらの表記でも動作します。",
       "zhipuaiOpenai": "ZhipuAIが検出されました。APIタイプを \"openai-compatible\" に変更することを検討してください。",
       "zhipuaiAnthropic": "ZhipuAIが検出されました。APIタイプを \"anthropic-compatible\" に変更することを検討してください。",
-      "urlHint": "完全なベースURLを入力してください。入力された通りに使用されます（例：https://api.example.com/v1）。"
+      "urlHint": "プロバイダーのベース URL を入力してください（例：https://api.example.com または https://api.example.com/v1）。SoloDawn は /v1 あり・なしの両方を試します。"
     },
     "hints": {
       "officialModels": "公式 API：組み込みのモデルリストを候補表示します。任意のモデル ID を直接入力することもできます。",

--- a/frontend/src/i18n/locales/ko/workflow.json
+++ b/frontend/src/i18n/locales/ko/workflow.json
@@ -194,10 +194,10 @@
       "modelIdRequired": "Model ID is required"
     },
     "warnings": {
-      "urlV1Compatible": "URL이 /v1로 끝납니다. URL은 입력한 그대로 사용되며, 경로가 자동으로 추가되지 않습니다. API에 /v1이 필요한 경우 그대로 두고, 그렇지 않은 경우 제거할 수 있습니다.",
+      "urlV1Compatible": "URL이 /v1로 끝납니다. SoloDawn은 입력한 그대로 먼저 시도한 뒤 /v1을 제외한 주소도 시도하므로 두 형식 모두 동작합니다.",
       "zhipuaiOpenai": "ZhipuAI가 감지되었습니다. API 유형을 \"openai-compatible\"로 변경하는 것을 고려하세요.",
       "zhipuaiAnthropic": "ZhipuAI가 감지되었습니다. API 유형을 \"anthropic-compatible\"로 변경하는 것을 고려하세요.",
-      "urlHint": "전체 기본 URL을 입력하세요. 입력한 그대로 사용됩니다 (예: https://api.example.com/v1)."
+      "urlHint": "공급자의 기본 URL을 입력하세요(예: https://api.example.com 또는 https://api.example.com/v1). SoloDawn이 /v1 포함/미포함 주소를 모두 시도합니다."
     },
     "hints": {
       "officialModels": "공식 API: 내장 모델 목록이 제안됩니다. 모델 ID를 직접 입력할 수도 있습니다.",

--- a/frontend/src/i18n/locales/zh-Hans/workflow.json
+++ b/frontend/src/i18n/locales/zh-Hans/workflow.json
@@ -195,10 +195,10 @@
       "modelIdRequired": "请选择或输入模型 ID"
     },
     "warnings": {
-      "urlV1Compatible": "URL 以 /v1 结尾。系统将原样使用您输入的 URL，不会自动追加路径。如果 API 需要 /v1 则保留，否则可以移除。",
+      "urlV1Compatible": "URL 以 /v1 结尾。系统会先按原样请求，再自动尝试去掉 /v1 的地址，两种写法都能用。",
       "zhipuaiOpenai": "检测到智谱AI地址。建议将 API 类型更改为 \"openai-compatible\"。",
       "zhipuaiAnthropic": "检测到智谱AI地址。建议将 API 类型更改为 \"anthropic-compatible\"。",
-      "urlHint": "请输入完整的基础 URL，系统将原样使用（例如 https://api.example.com/v1）。"
+      "urlHint": "请输入服务商的基础 URL（例如 https://api.example.com 或 https://api.example.com/v1）。系统会自动尝试带 /v1 和不带 /v1 两种地址。"
     },
     "hints": {
       "officialModels": "官方 API：已内置模型列表，也可直接输入任意模型 ID。",

--- a/frontend/src/stores/modelStore.ts
+++ b/frontend/src/stores/modelStore.ts
@@ -95,7 +95,15 @@ export const useModelStore = create<ModelStoreState>((set, get) => ({
       });
 
       if (!response.ok) {
-        throw new Error(`Failed to fetch models: ${response.statusText}`);
+        // Surface the backend's explanation (which endpoints were tried and why
+        // each failed) instead of a bare status line — a compatible endpoint has
+        // no built-in catalog to fall back on, so an opaque failure leaves the
+        // model dropdown simply empty.
+        const detail = await response
+          .json()
+          .then((body: { message?: string; error?: string }) => body.message ?? body.error)
+          .catch(() => undefined);
+        throw new Error(detail ?? `Failed to fetch models: ${response.statusText}`);
       }
 
       const data = await response.json();
@@ -131,6 +139,9 @@ export const useModelStore = create<ModelStoreState>((set, get) => ({
           baseUrl: model.baseUrl,
           apiKey: model.apiKey,
           modelId: model.modelId,
+          // Verification must exercise the API surface the bound CLI really
+          // calls (Codex speaks the OpenAI Responses API, not Chat Completions).
+          cliTypeId: model.cliTypeId,
         }),
       });
 
@@ -144,7 +155,7 @@ export const useModelStore = create<ModelStoreState>((set, get) => ({
       // Update model verification status
       get().setVerified(model.id, verified);
 
-      set({ isVerifying: null });
+      set({ error: verified ? null : ((data.detail as string) ?? null), isVerifying: null });
       return verified;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Verification failed';


### PR DESCRIPTION
修复用户在自定义（DIY）工作流中报告的 5 个问题。逐条定位到 5 处彼此独立的根因，无一处以症状掩盖。

对应 cnb issue [#8](https://cnb.cool/huanchong-AI/solodawn/-/issues/8)（手动工作流异常要求输入密码）；并修复了 [#6](https://cnb.cool/huanchong-AI/solodawn/-/issues/6)（工作区只生成 .git）中属于 Codex 沙箱的那一半原因。

---

## 1. 开始工作流时弹出不明来源的"密码"框

**根因**：`crates/services/src/services/terminal/prompt_detector.rs` 的 `PASSWORD_RE` 是裸关键词匹配 —— 任何含 `password` / `token` / `secret` / `api key` / `credential` 的行都被判为最高优先级的密码提示。`PromptKind::Password` 直接走 `ask_password()`，工作流随即暂停等待用户输入。DIY 工作流注入的任务说明与质量契约文本经 CLI TUI 回显后即触发。

**修复**：改为要求真正的交互式提示形态 —— 关键词后紧跟行尾终止符（`:` `：` `?` `？` `>`）、行长不超过 120 字符、且排除列表/编号/标题等文档结构前缀。同时把触发行带进弹窗原因，用户能看清"这到底是什么密码"，而不是面对一个无名输入框。

`detect_input` 仍按**关键词**（而非提示形态）抑制，确保 LLM 永远不会自动回答涉密提问。

## 2. 设置的 CLI 与 LLM 和实际运行的不一致

**根因**：`cc_switch.rs` 的 `build_launch_config` 只为 Claude Code 与 Codex 生成配置，其余 6 个受支持 CLI（amp / cursor-agent / qwen-code / copilot / droid / opencode）一律返回 `empty_config()`。向导里选定、已入库、界面照常显示的 CLI + 模型 + 凭证，在拉起进程时被整体丢弃，CLI 转而使用自己的全局配置 —— 仅有一条用户看不到的 `tracing::warn!`。

这与用户"仅用 Claude 或仅用 Codex 时无此问题、混用时才出现"的观察完全吻合。

**修复**：按模型的 provider 族注入标准 provider 环境变量（用的是各家 SDK 的官方变量名，不是逐个 CLI 猜的私有变量）；无法完全固定模型的情况改为显式告警，而不是静默偏离。模型的 `apiType` / `baseUrl` 也随之落库（`InlineModelConfig` + `create_custom`，用 `COALESCE` 保证旧客户端不会抹掉已有路由信息），协议族不再靠 base URL 猜测。

## 3. 配置为串行的 3 个终端表现为并行

**根因**：`workflows.rs` 的 DIY 派发对同一任务下的**所有**终端做扇出，各终端间仅隔约 2 秒，从不等待上一个终端结束。默认并发上限是 4，所以用户的 3 个终端全部拿到 PTY 并同时开跑。

**修复**：任务内终端本就是有序流水线（`order_index` 升序，如 前端→后端→审计），现改为上一阶段进入终止态后才放行下一阶段，并设 6 小时等待上限以免单个阶段永久卡住流水线。任务之间维持并行（各任务在独立分支上，属既定设计）。

两处配套修正，否则串行化本身会引入新问题：
- 未派发的阶段不再被静默窗口监视器误判为"已完成"（它们按设计就是安静的）；
- 长时间等待后重新读取终端行，避免用陈旧的 PTY 会话 id 派发到已死的 PTY。

## 4. Codex 模型测试连接通过，但 agent 中完全不可用

两处根因，**均已用本机 codex-cli 0.144.5 实际运行验证，不是推断**：

**(a) config.toml 的键落错了 TOML 表。** `approval_policy` 与 `sandbox_permissions` 被写在 `[model_providers.<key>]` 之后，按 TOML 作用域它们落进了 provider 表内：

```
$ codex --strict-config exec "hi"
Error loading config.toml:
  unknown configuration field `model_providers.custom.approval_policy`
```

不加 `--strict-config` 则被静默忽略 —— 于是审批策略与沙箱策略从未生效。另外 `sandbox_permissions` 已被 Codex 移除（同样被 `--strict-config` 拒绝），现用 `sandbox_mode`。二者改为写在 provider 表之前，沙箱设为 `workspace-write`：**无法写工作区的 agent 只会留下一个 `.git`**，这正是 issue #6 的现象之一。

**(b) 测试连接验的不是 Codex 实际会用的 API 面。** 验证走 `/chat/completions`，而 Codex 只支持 OpenAI **Responses** 协议 —— `wire_api = "chat"` 已被 Codex 移除：

```
$ codex exec "hi"      # wire_api = "chat"
Error loading config.toml: `wire_api = "chat"` is no longer supported.
```

只实现 Chat Completions 的中转端点因此**测试通过却完全带不动 Codex**。绑定到 Codex 的模型现按 Responses API 验证，失败时明确说明原因。

顺带修正 `terminal.rs` 里"Codex: `--yolo`"的陈旧注释 —— 该 flag 在 0.144.5 不存在，审批是配置驱动的。

## 5. 填入兼容 base URL 后获取不到模型列表

**根因**：`list_openai_models` 直接请求 `{base}/models`，不像 Anthropic 分支那样自动补 `/v1`。服务商对 base URL 的写法并不统一（有的发布 `https://host`，有的发布 `https://host/v1`），猜错一种就是 404。而兼容端点的 `OFFICIAL_MODELS` 是空数组，前端兜底后只能显示一个**空列表**配一句"请检查 API Key" —— 用户完全无从判断真实原因。

**修复**：对带与不带 `/v1` 两种写法依次尝试（并保证不会拼出 `/v1/v1`），把真实失败原因（试了哪些地址、各自为何失败）一路回传到前端。Anthropic 兼容分支同时发送 `x-api-key` 与 `Authorization`，适配多协议网关。5 种语言的 base URL 提示文案同步更新。

---

## 验证

| 门禁 | 结果 |
|---|---|
| `cargo test --workspace --lib` | 1176 通过 / 0 失败 |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | 无告警 |
| 前端 `vitest run` | 529 通过 / 0 失败 |
| `tsc --noEmit` | 干净 |
| `eslint --max-warnings 0` | 干净 |

新增测试覆盖 issue #8 要求的负例（含敏感词的正常文本不得触发）与正例（真实提示必须触发），以及 Codex config.toml 的 TOML 表归属（解析后断言键落在哪张表，而不只是断言文本存在）、端点候选拼接、串行阶段门控。

## 需要留意

- 第 2 项对 6 个 CLI 注入的是各 provider SDK 的官方环境变量。本机只装了 `droid`，其余 5 个 CLI 是否读取这些变量**未能逐一实测**；因此保留了显式告警而非假定生效 —— 这比原先的静默丢弃是严格改进，但不宜当作"已完全固定模型"。
- issue #6 中 OpenCode 侧的表现，本 PR 通过第 2 项改善（此前它连凭证都拿不到），但未做 OpenCode 专项实测，不宜视为该 issue 已完全关闭。


---

## 6. 手动工作流查看历史记录：翻页跳版 + 内容错乱

（用户后续追加反馈，同一 PR 一并修掉。）

**布局根因**：历史面板从根容器到 `<pre>` 这一路的 flex item 都没有 `min-w-0`，而 flex item 的 `min-width` 默认是 `auto` —— 它拒绝收缩到内容 min-content 宽度以下。`<pre>` 用的是 `break-words`（即 `overflow-wrap: break-word`），这个值只在渲染时换行，**并不会降低 min-content 宽度**（`break-all` / `anywhere` 才会）。于是当前页里最长的那串不换行文本会把整个右侧面板撑开；每页最长串不一样，所以每点一次上一页/下一页宽度就变一次。分页条用的是 `justify-between`，面板一被撑宽，两个按钮就被甩到极左极右、页码留在中间 —— 正是截图里的样子。

**修复**：各层补 `min-w-0`，`<pre>` 改用 `break-all`，左侧列表与头部按钮组标记 `shrink-0`，头部长 ID 改为 `truncate`。另外补上翻页时滚动容器归零（此前会停在上一页的滚动位置，看起来就像"内容跑到中间了"），以及对 `historyPage` 的钳制（重新加载后页数变少时不会停在空页）。

**内容根因**：日志表里每一行是一段**原始 PTY 分片**，边界是任意的。旧代码逐行把裸 `\r` 直接替换成 `\n`，于是 CLI 原地重绘的每一帧都变成了独立的一行 —— 这就是历史里反复出现的 "Gesticulating…"，以及 "Rnnig…" 这类被后一帧半覆盖后留下的残片。

**修复**：先把分片拼回完整流（一次重绘经常跨分片边界），再按终端语义排版：`\r` 回到列 0 覆盖写入；`CSI n K`（erase in line）在 `stripAnsi` 抹掉它之前先换成标记，排版时再应用 —— 否则较长旧帧的尾巴会留在较短新帧后面；最后丢弃 ESC 与残余控制字符，并裁掉结尾空行。

新增 10 个测试：翻页后滚动归零、`break-all` 类名、以及排版函数的各分支（重绘折叠、跨分片重绘、erase-in-line、制表符与中间空行保留、结尾空行裁剪）。

**验证增量**：前端 `vitest run` 539 通过 / 0 失败，`tsc --noEmit` 与 `eslint --max-warnings 0` 均干净。
